### PR TITLE
feat(companion): Doubao Seedream provider + multi-provider architecture (v0.5.0)

### DIFF
--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honlnk/image-studio-companion",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Local CLI companion for GPT Image Studio image API credential proxying.",
   "type": "module",
   "bin": {

--- a/companion/src/main.ts
+++ b/companion/src/main.ts
@@ -16,7 +16,7 @@ import {
   stopManagedProcess,
 } from "./processManager.js";
 
-const VERSION = "0.3.0";
+const VERSION = "0.5.0";
 const DEFAULT_PORT = "19750";
 const DEFAULT_SESSION_TTL_DAYS = "30";
 

--- a/companion/src/main.ts
+++ b/companion/src/main.ts
@@ -43,6 +43,12 @@ const PROVIDER_PRESETS: ProviderPreset[] = [
     defaultBaseUrl: "https://open.bigmodel.cn/api/paas/v4/images",
     defaultModel: "glm-image",
   },
+  {
+    id: "doubao",
+    label: "豆包 Seedream（火山方舟 ByteDance）",
+    defaultBaseUrl: "https://ark.cn-beijing.volces.com/api/v3/images",
+    defaultModel: "doubao-seedream-5-0-lite",
+  },
 ];
 
 type ServeLikeOptions = {

--- a/companion/src/providers/doubao.test.ts
+++ b/companion/src/providers/doubao.test.ts
@@ -1,0 +1,385 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { doubaoAdapter, normalizeDoubaoSize } from "./doubao.js";
+import type { ProviderConfig, SizeConstraints } from "./types.js";
+
+const CONSTRAINTS: SizeConstraints = {
+  step: 1,
+  min: 512,
+  max: 4096,
+  maxPixels: 16777216,
+  minPixels: 3686400,
+  maxAspectRatio: 16,
+  defaultSize: "2048x2048",
+};
+
+const CONFIG: ProviderConfig = {
+  provider: "doubao",
+  apiBaseUrl: "https://ark.cn-beijing.volces.com/api/v3/images",
+  apiKey: "doubao-test-key",
+  model: "doubao-seedream-5-0-lite",
+};
+
+describe("normalizeDoubaoSize", () => {
+  it("maps auto to default size", () => {
+    expect(normalizeDoubaoSize("auto", CONSTRAINTS)).toBe("2048x2048");
+  });
+
+  it("maps empty string to default size", () => {
+    expect(normalizeDoubaoSize("", CONSTRAINTS)).toBe("2048x2048");
+  });
+
+  it("passes through a valid WxH within range", () => {
+    expect(normalizeDoubaoSize("2048x2048", CONSTRAINTS)).toBe("2048x2048");
+    expect(normalizeDoubaoSize("3840x2160", CONSTRAINTS)).toBe("3840x2160");
+  });
+
+  it("does NOT align to step (step=1, accepts any integer)", () => {
+    // 豆包无步长对齐：2345x1234 原样保留（只要在像素范围内）
+    expect(normalizeDoubaoSize("2345x2345", CONSTRAINTS)).toBe("2345x2345");
+  });
+
+  it("scales up when pixels below minPixels", () => {
+    // 1280x1280 = 1638400 < minPixels 3686400，应放大长边
+    const result = normalizeDoubaoSize("1280x1280", CONSTRAINTS);
+    const [w, h] = result.split("x").map(Number);
+    expect(w * h).toBeGreaterThanOrEqual(CONSTRAINTS.minPixels);
+  });
+
+  it("scales down when pixels above maxPixels", () => {
+    // 6000x6000 = 36000000 > maxPixels 16777216，应缩小
+    const result = normalizeDoubaoSize("6000x6000", CONSTRAINTS);
+    const [w, h] = result.split("x").map(Number);
+    expect(w * h).toBeLessThanOrEqual(CONSTRAINTS.maxPixels);
+  });
+
+  it("clamps aspect ratio above maxAspectRatio (16)", () => {
+    // 100:1 比例远超 16:1，宽边应被钳到 16 倍短边
+    const result = normalizeDoubaoSize("6400x64", CONSTRAINTS);
+    const [w, h] = result.split("x").map(Number);
+    expect(w / h).toBeLessThanOrEqual(16 + 0.01); // 允许舍入误差
+  });
+
+  it("clamps aspect ratio below 1/maxAspectRatio (1/16)", () => {
+    // 1:100 比例，高边应被钳到 16 倍宽边
+    const result = normalizeDoubaoSize("64x6400", CONSTRAINTS);
+    const [w, h] = result.split("x").map(Number);
+    expect(h / w).toBeLessThanOrEqual(16 + 0.01);
+  });
+
+  it("handles ratio format (16:9)", () => {
+    const result = normalizeDoubaoSize("16:9", CONSTRAINTS);
+    const [w, h] = result.split("x").map(Number);
+    expect(w).toBeGreaterThan(h);
+    expect(w * h).toBeGreaterThanOrEqual(CONSTRAINTS.minPixels);
+    expect(w * h).toBeLessThanOrEqual(CONSTRAINTS.maxPixels);
+  });
+
+  it("handles ratio format (9:16 portrait)", () => {
+    const result = normalizeDoubaoSize("9:16", CONSTRAINTS);
+    const [w, h] = result.split("x").map(Number);
+    expect(h).toBeGreaterThan(w);
+  });
+
+  it("accepts unicode × separator", () => {
+    expect(normalizeDoubaoSize("2048×2048", CONSTRAINTS)).toBe("2048x2048");
+  });
+
+  it("falls back to default for unrecognizable size", () => {
+    expect(normalizeDoubaoSize("bogus", CONSTRAINTS)).toBe("2048x2048");
+  });
+
+  it("output always uses lowercase x separator", () => {
+    const result = normalizeDoubaoSize("16:9", CONSTRAINTS);
+    expect(result).toMatch(/^\d+x\d+$/);
+  });
+});
+
+describe("doubaoAdapter.generate", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("sends b64_json response_format and watermark=false, strips background/output_format/extra", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({ data: [{ b64_json: "ZGF0YQ==" }] }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await doubaoAdapter.generate(
+      {
+        model: "doubao-seedream-5-0-lite",
+        prompt: "a cat",
+        size: "2048x2048",
+        background: "opaque",
+        outputFormat: "png",
+        extra: { quality: "high" }, // extra 应被裁掉
+      },
+      CONFIG,
+    );
+
+    expect(result.b64Json).toBe("ZGF0YQ==");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://ark.cn-beijing.volces.com/api/v3/images/generations");
+    const body = JSON.parse(String(init.body));
+    // D2: 固定 response_format=b64_json
+    expect(body.response_format).toBe("b64_json");
+    // D3: 固定 watermark=false
+    expect(body.watermark).toBe(false);
+    // 豆包只认 model/prompt/size，background/output_format/extra 应被裁掉
+    expect(body).toEqual({
+      model: "doubao-seedream-5-0-lite",
+      prompt: "a cat",
+      size: "2048x2048",
+      response_format: "b64_json",
+      watermark: false,
+    });
+    expect(body.background).toBeUndefined();
+    expect(body.output_format).toBeUndefined();
+    expect(body.quality).toBeUndefined();
+  });
+
+  it("normalizes size=auto to default 2048x2048", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({ data: [{ b64_json: "ZGF0YQ==" }] }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await doubaoAdapter.generate(
+      {
+        model: "doubao-seedream-5-0-lite",
+        prompt: "a cat",
+        size: "auto",
+        background: "auto",
+        outputFormat: "png",
+        extra: {},
+      },
+      CONFIG,
+    );
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(String(init.body));
+    expect(body.size).toBe("2048x2048");
+  });
+
+  it("throws upstream disconnect when fetch throws", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Promise.reject(new Error("ECONNRESET"))),
+    );
+    await expect(
+      doubaoAdapter.generate(
+        {
+          model: "x",
+          prompt: "x",
+          size: "auto",
+          background: "auto",
+          outputFormat: "png",
+          extra: {},
+        },
+        CONFIG,
+      ),
+    ).rejects.toThrow("服务器主动断开了连接");
+  });
+
+  it("throws upstream error message on non-2xx", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ error: { message: "prompt 违规" } }), {
+            status: 400,
+          }),
+      ),
+    );
+    await expect(
+      doubaoAdapter.generate(
+        {
+          model: "x",
+          prompt: "x",
+          size: "auto",
+          background: "auto",
+          outputFormat: "png",
+          extra: {},
+        },
+        CONFIG,
+      ),
+    ).rejects.toThrow("prompt 违规");
+  });
+
+  it("throws when response has no b64_json", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () => new Response(JSON.stringify({ data: [{}] }), { status: 200 }),
+      ),
+    );
+    await expect(
+      doubaoAdapter.generate(
+        {
+          model: "x",
+          prompt: "x",
+          size: "auto",
+          background: "auto",
+          outputFormat: "png",
+          extra: {},
+        },
+        CONFIG,
+      ),
+    ).rejects.toThrow(/data\[0\]\.b64_json|没有/);
+  });
+
+  it("does NOT call urlToB64 (takes b64_json directly)", async () => {
+    // 豆包 generate 只应发一次 fetch（generations 请求），不应再 fetch URL 下载图片。
+    // 若错误地走了 urlToB64，fetch 会被调用第二次。
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({ data: [{ b64_json: "ZGF0YQ==" }] }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await doubaoAdapter.generate(
+      {
+        model: "x",
+        prompt: "x",
+        size: "auto",
+        background: "auto",
+        outputFormat: "png",
+        extra: {},
+      },
+      CONFIG,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1); // D2: 只一次，不经 URL 下载
+  });
+});
+
+describe("doubaoAdapter.edit", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("posts to /generations with image data URL, response_format, watermark=false", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({ data: [{ b64_json: "ZWRpdA==" }] }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const imageBlob = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const result = await doubaoAdapter.edit(
+      {
+        model: "doubao-seedream-5-0-260128",
+        prompt: "把背景换成蓝天",
+        size: "2048x2048",
+        background: "auto",
+        outputFormat: "png",
+        extra: {},
+        images: [{ blob: imageBlob, name: "ref.png", mimeType: "image/png" }],
+        editExtra: {},
+      },
+      { ...CONFIG, model: "doubao-seedream-5-0-260128" },
+    );
+
+    expect(result.b64Json).toBe("ZWRpdA==");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    // 豆包图生图不分独立 edits 端点，参考图塞进 /generations 的 image 字段
+    expect(url).toBe("https://ark.cn-beijing.volces.com/api/v3/images/generations");
+
+    const body = JSON.parse(String(init.body));
+    expect(body.model).toBe("doubao-seedream-5-0-260128");
+    expect(body.prompt).toBe("把背景换成蓝天");
+    expect(body.size).toBe("2048x2048");
+    expect(body.response_format).toBe("b64_json");
+    expect(body.watermark).toBe(false);
+    // image 字段是 base64 data URL
+    expect(body.image).toBe(`data:image/png;base64,${imageBlob.toString("base64")}`);
+    // 不应含 background/output_format（豆包不认）/ mask（不支持）
+    expect(body.background).toBeUndefined();
+    expect(body.output_format).toBeUndefined();
+    expect(body.mask).toBeUndefined();
+  });
+
+  it("throws when no reference image provided", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response()));
+
+    await expect(
+      doubaoAdapter.edit(
+        {
+          model: "x",
+          prompt: "x",
+          size: "auto",
+          background: "auto",
+          outputFormat: "png",
+          extra: {},
+          images: [], // 无参考图
+          editExtra: {},
+        },
+        CONFIG,
+      ),
+    ).rejects.toThrow("参考图");
+  });
+
+  it("throws upstream disconnect when fetch throws", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Promise.reject(new Error("ECONNRESET"))),
+    );
+    await expect(
+      doubaoAdapter.edit(
+        {
+          model: "x",
+          prompt: "x",
+          size: "auto",
+          background: "auto",
+          outputFormat: "png",
+          extra: {},
+          images: [{ blob: Buffer.from([0x00]), name: "r.png", mimeType: "image/png" }],
+          editExtra: {},
+        },
+        CONFIG,
+      ),
+    ).rejects.toThrow("服务器主动断开了连接");
+  });
+});
+
+describe("doubaoAdapter static metadata", () => {
+  it("declares Doubao capability (edit=true, mask=false)", () => {
+    expect(doubaoAdapter.capability).toEqual({
+      generate: true,
+      edit: true,
+      mask: false,
+      backgrounds: ["auto", "opaque"],
+      outputFormats: ["png", "jpeg"],
+    });
+  });
+
+  it("declares Doubao size constraints (step=1, minPixels=3686400)", () => {
+    expect(doubaoAdapter.sizeConstraints).toEqual({
+      step: 1,
+      min: 512,
+      max: 4096,
+      maxPixels: 16777216,
+      minPixels: 3686400,
+      maxAspectRatio: 16,
+      defaultSize: "2048x2048",
+    });
+  });
+
+  it("declares resolution options [2k, 3k, 4k] (no 1k, has native 3k)", () => {
+    expect(doubaoAdapter.resolutionOptions.map((o) => o.value)).toEqual([
+      "2k",
+      "3k",
+      "4k",
+    ]);
+    // 不含 1k（豆包 minPixels 达不到）
+    expect(doubaoAdapter.resolutionOptions.find((o) => o.value === "1k")).toBeUndefined();
+  });
+});

--- a/companion/src/providers/doubao.ts
+++ b/companion/src/providers/doubao.ts
@@ -1,0 +1,289 @@
+import type {
+  OpenAIImageEditRequest,
+  OpenAIImageRequest,
+  OpenAIImageResult,
+  ProviderAdapter,
+  ProviderCapability,
+  ProviderConfig,
+  ResolutionOption,
+  SizeConstraints,
+} from "./types.js";
+
+/**
+ * 豆包 Seedream（火山方舟 ByteDance）adapter。
+ *
+ * 与 GLM 一样走 OpenAI 兼容的 /images/generations 端点、Bearer 鉴权，
+ * 但在三个维度上有本质差异，因此是独立 adapter（不复用 glm.ts）：
+ *
+ *   1. size 约束模型不同：豆包是「总像素范围 [3.6M, 16M] + 宽高比 [1/16, 16]」双约束，
+ *      有像素下限（GLM 无下限），且无步长对齐（step=1）。
+ *   2. 原生支持图生图（SeedEdit / edits 端点），capability.edit=true。
+ *      GLM 全图编辑已确认不做。
+ *   3. 豆包特有字段：response_format（D2 固定要 b64_json 跳过 URL→b64）、
+ *      watermark（D3 固定关掉，不要「AI 生成」水印）。
+ *
+ * 不支持 mask 局部重绘（与 GLM 一致的国产模型缺口），capability.mask=false，
+ * 带 mask 的编辑请求由 route 层返回 400。
+ *
+ * 详见 docs/companion-doubao-plan.md。
+ */
+
+/** 豆包的 size 硬规则（经查火山方舟 Seedream 官方文档确认）。 */
+const SIZE_CONSTRAINTS: SizeConstraints = {
+  step: 1, // D6：豆包无步长对齐，任意整数像素都接受
+  min: 512, // 单边软下限兜底（豆包靠总像素+宽高比约束，单边无硬下限）
+  max: 4096, // 单边软上限（总像素上限 2^24 决定，4096 是安全值）
+  maxPixels: 16777216, // 2^24，豆包总像素上限
+  minPixels: 3686400, // 豆包总像素下限（约 1920²），自定义尺寸路径校验用
+  maxAspectRatio: 16, // 宽高比上限 [1/16, 16]
+  defaultSize: "2048x2048", // 2K 正方形，豆包最稳定档位，刚过下限
+};
+
+/**
+ * 豆包能力声明。
+ * - edit=true：原生支持图生图（SeedEdit / edits 端点）。
+ * - mask=false：不支持 mask 局部重绘（国产模型普遍缺口）。
+ * - backgrounds 去 transparent：豆包不支持透明背景。
+ * - outputFormats 去 webp：Seedream 主力输出 png/jpeg。
+ */
+const CAPABILITY: ProviderCapability = {
+  generate: true,
+  edit: true,
+  mask: false,
+  backgrounds: ["auto", "opaque"],
+  outputFormats: ["png", "jpeg"],
+};
+
+/**
+ * 豆包支持的分辨率档位（companion 声明、web 渲染）。
+ * - 不含 1K：豆包 minPixels≈3.6M，1K（1M）达不到下限。
+ * - 含 3K：豆包原生档，web 此前没有。
+ */
+const RESOLUTION_OPTIONS: readonly ResolutionOption[] = [
+  { value: "2k", label: "2K", targetPixels: 2048 * 2048 },
+  { value: "3k", label: "3K", targetPixels: 2880 * 1620 },
+  { value: "4k", label: "4K", targetPixels: 4096 * 2160 },
+];
+
+/** 豆包默认 base url（火山方舟方舟服务）。login 时可被覆盖。 */
+const DEFAULT_DOUBAO_BASE_URL = "https://ark.cn-beijing.volces.com/api/v3/images";
+/** 豆包默认 model（Seedream 5.0 lite，豆包当前最强模型）。login 时可填自定义。 */
+const DEFAULT_DOUBAO_MODEL = "doubao-seedream-5-0-lite";
+
+export const doubaoAdapter: ProviderAdapter = {
+  id: "doubao",
+  capability: CAPABILITY,
+  sizeConstraints: SIZE_CONSTRAINTS,
+  resolutionOptions: RESOLUTION_OPTIONS,
+
+  describe(config: ProviderConfig) {
+    return { label: config.model ?? DEFAULT_DOUBAO_MODEL, providerId: "doubao" };
+  },
+
+  async generate(
+    request: OpenAIImageRequest,
+    config: ProviderConfig,
+  ): Promise<OpenAIImageResult> {
+    const apiUrl = `${config.apiBaseUrl.replace(/\/+$/, "")}/generations`;
+    const model = config.model ?? DEFAULT_DOUBAO_MODEL;
+    const size = normalizeDoubaoSize(request.size, SIZE_CONSTRAINTS);
+
+    // 裁剪：豆包只认 model/prompt/size，固定 response_format=b64_json（D2）+ watermark=false（D3）。
+    // 丢弃 background/output_format/extra（豆包不支持这些参数）。
+    let response: Response;
+    try {
+      response = await fetch(apiUrl, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${config.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model,
+          prompt: request.prompt,
+          size,
+          response_format: "b64_json",
+          watermark: false,
+        }),
+      });
+    } catch {
+      throw new Error(UPSTREAM_DISCONNECT_MESSAGE);
+    }
+
+    const payload = await parseJsonResponse(response);
+    const b64Json = payload?.data?.[0]?.b64_json;
+    if (!b64Json) {
+      throw new Error(extractErrorMessage(payload) ?? "豆包响应中没有 data[0].b64_json");
+    }
+    // D2：直接拿 b64_json，不走 urlToB64（豆包支持 response_format=b64_json）。
+    return { b64Json };
+  },
+
+  async edit(
+    request: OpenAIImageEditRequest,
+    config: ProviderConfig,
+  ): Promise<OpenAIImageResult> {
+    // 豆包图生图不分独立 edits 端点——参考图作为 JSON 的 image 字段塞进 /generations。
+    // （验证来源：/images/edits 返回 404；Seedream 文档用 images/generations + image 做图生图）
+    const apiUrl = `${config.apiBaseUrl.replace(/\/+$/, "")}/generations`;
+    const model = config.model ?? DEFAULT_DOUBAO_MODEL;
+    const size = normalizeDoubaoSize(request.size, SIZE_CONSTRAINTS);
+    // 豆包 edit 用第一张参考图作为 image（SeedEdit 全图编辑）。
+    const reference = request.images[0];
+    if (!reference) {
+      throw new Error("豆包图生图需要至少一张参考图。");
+    }
+    // image 字段：base64 data URL（OpenAI 兼容惯例：data:<mime>;base64,<b64>）
+    const imageDataUrl = `data:${reference.mimeType};base64,${reference.blob.toString("base64")}`;
+
+    let response: Response;
+    try {
+      response = await fetch(apiUrl, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${config.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model,
+          prompt: request.prompt,
+          size,
+          image: imageDataUrl,
+          response_format: "b64_json",
+          watermark: false,
+        }),
+      });
+    } catch {
+      throw new Error(UPSTREAM_DISCONNECT_MESSAGE);
+    }
+
+    const payload = await parseJsonResponse(response);
+    const b64Json = payload?.data?.[0]?.b64_json;
+    if (!b64Json) {
+      throw new Error(extractErrorMessage(payload) ?? "豆包响应中没有 data[0].b64_json");
+    }
+    return { b64Json };
+  },
+};
+
+const UPSTREAM_DISCONNECT_MESSAGE =
+  "服务器主动断开了连接，未返回任何响应。通常是提示词中存在不合规内容，触发了平台的内容审核策略，请调整提示词后重试。";
+
+/**
+ * 把 OpenAI 形状的 size 规整成豆包合法的 `宽x高`。
+ *
+ * 处理的输入：
+ * - "auto" → 豆包默认尺寸（defaultSize，2048x2048）
+ * - "WxH" → 钳总像素范围 + 宽高比范围（无步长对齐）
+ * - 比例格式（如 "16:9"，来自 web 的 ratio 预设）→ 按比例 + 默认像素算出尺寸再规整
+ *
+ * 规整策略（豆包双约束）：
+ *   1. 宽高比必须在 [1/maxAspectRatio, maxAspectRatio] 内（超了钳到边界）
+ *   2. 总像素必须在 [minPixels, maxPixels] 内
+ *      - 超上限：按比例缩小长边
+ *      - 低于下限：按比例放大长边
+ *
+ * 注意：豆包无步长对齐（step=1），不像 GLM 需要对齐 32 的倍数。
+ *
+ * 这是纯函数，便于单测；adapter 内部调用它。
+ */
+export function normalizeDoubaoSize(
+  size: string,
+  constraints: SizeConstraints = SIZE_CONSTRAINTS,
+): string {
+  const trimmed = size.trim();
+
+  if (trimmed === "auto" || trimmed === "") {
+    return constraints.defaultSize;
+  }
+
+  let width: number;
+  let height: number;
+
+  // 比例格式（web 的 ratio 预设会发 "16:9" 这类）
+  if (trimmed.includes(":")) {
+    const dims = dimensionsFromRatio(trimmed, constraints);
+    width = dims.width;
+    height = dims.height;
+  } else {
+    // WxH 格式（web 的 custom 会发 "2048x2048" 这类）
+    const match = /^(\d+)\s*[x×]\s*(\d+)$/i.exec(trimmed);
+    if (match) {
+      width = Number(match[1]);
+      height = Number(match[2]);
+    } else {
+      // 无法识别 → 回退默认
+      console.warn(`[doubao] 无法识别的 size "${trimmed}"，回退默认 ${constraints.defaultSize}`);
+      return constraints.defaultSize;
+    }
+  }
+
+  return finalizeSize(width, height, constraints);
+}
+
+/** 按比例 + 目标像素（取 maxPixels 与 minPixels 的几何中间值作基准）算出原始尺寸。 */
+function dimensionsFromRatio(ratio: string, constraints: SizeConstraints) {
+  const [w, h] = ratio.split(":").map(Number);
+  if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) {
+    return { width: 0, height: 0 };
+  }
+  const aspect = w / h;
+  // 基准取上下限的几何平均，落在豆包合法区间内
+  const basePixels = Math.sqrt(constraints.minPixels * constraints.maxPixels);
+  let width = Math.round(Math.sqrt(basePixels * aspect));
+  let height = Math.round(width / aspect);
+  return { width, height };
+}
+
+/** 规整到豆包合法：钳宽高比 → 钳总像素范围（双向）。无步长对齐。 */
+function finalizeSize(
+  width: number,
+  height: number,
+  constraints: SizeConstraints,
+): string {
+  let w = Math.max(constraints.step, Math.round(width));
+  let h = Math.max(constraints.step, Math.round(height));
+
+  const maxAspect = constraints.maxAspectRatio;
+  if (maxAspect !== null) {
+    // 钳宽高比：超了就把长边缩到 maxAspect 倍短边
+    const aspect = w / h;
+    if (aspect > maxAspect) {
+      w = Math.round(h * maxAspect);
+    } else if (aspect < 1 / maxAspect) {
+      h = Math.round(w * maxAspect);
+    }
+  }
+
+  // 钳总像素范围：超上限缩长边，低于下限放长边（保持比例近似）
+  const clampPixels = (targetPixels: number) => {
+    const ratio = Math.sqrt(targetPixels / (w * h));
+    w = Math.max(constraints.step, Math.round(w * ratio));
+    h = Math.max(constraints.step, Math.round(h * ratio));
+  };
+  if (w * h > constraints.maxPixels) {
+    clampPixels(constraints.maxPixels);
+  } else if (w * h < constraints.minPixels) {
+    clampPixels(constraints.minPixels);
+  }
+
+  return `${w}x${h}`;
+}
+
+async function parseJsonResponse(response: Response): Promise<Record<string, any> | null> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text) as Record<string, any>;
+  } catch {
+    return null;
+  }
+}
+
+function extractErrorMessage(payload: Record<string, any> | null): string | null {
+  if (!payload) return null;
+  const err = payload.error;
+  if (typeof err === "string") return err;
+  if (err && typeof err.message === "string") return err.message;
+  return null;
+}

--- a/companion/src/providers/glm.test.ts
+++ b/companion/src/providers/glm.test.ts
@@ -256,4 +256,9 @@ describe("glmAdapter static metadata", () => {
       defaultSize: "1280x1280",
     });
   });
+
+  it("declares resolution options [1k, 2k] (GLM maxPixels=4M, no 4k)", () => {
+    expect(glmAdapter.resolutionOptions.map((o) => o.value)).toEqual(["1k", "2k"]);
+    expect(glmAdapter.resolutionOptions.find((o) => o.value === "4k")).toBeUndefined();
+  });
 });

--- a/companion/src/providers/glm.ts
+++ b/companion/src/providers/glm.ts
@@ -4,6 +4,7 @@ import type {
   ProviderAdapter,
   ProviderCapability,
   ProviderConfig,
+  ResolutionOption,
   SizeConstraints,
 } from "./types.js";
 import { urlToB64 } from "./urlToB64.js";
@@ -50,6 +51,17 @@ const CAPABILITY: ProviderCapability = {
   outputFormats: ["png", "jpeg"],
 };
 
+/**
+ * GLM 支持的分辨率档位。GLM maxPixels=4194304（2²²），真实只到 2K，
+ * 4K（8.3M）生成不了——这里只声明 1K/2K，是 GLM 的真实能力。
+ * （此前 web 是靠 availableResolutionValues 按 maxPixels 运行时过滤掉 4K，
+ *  D1 统一机制后该特判删除，GLM 4K 不显示是因为这里压根没声明。）
+ */
+const RESOLUTION_OPTIONS: readonly ResolutionOption[] = [
+  { value: "1k", label: "1K", targetPixels: 1024 * 1024 },
+  { value: "2k", label: "2K", targetPixels: 2048 * 2048 },
+];
+
 /** GLM 默认 base url（智谱开放平台）。login 时可被覆盖。 */
 const DEFAULT_GLM_BASE_URL = "https://open.bigmodel.cn/api/paas/v4/images";
 /** GLM 默认 model（智谱 2026 旗舰文生图模型）。login 时可填自定义。 */
@@ -59,6 +71,7 @@ export const glmAdapter: ProviderAdapter = {
   id: "glm",
   capability: CAPABILITY,
   sizeConstraints: SIZE_CONSTRAINTS,
+  resolutionOptions: RESOLUTION_OPTIONS,
 
   describe(config: ProviderConfig) {
     return { label: config.model ?? DEFAULT_GLM_MODEL, providerId: "glm" };

--- a/companion/src/providers/openai.test.ts
+++ b/companion/src/providers/openai.test.ts
@@ -187,4 +187,12 @@ describe("openaiAdapter static metadata", () => {
       defaultSize: "1024x1024",
     });
   });
+
+  it("declares resolution options [1k, 2k, 4k] (OpenAI full range)", () => {
+    expect(openaiAdapter.resolutionOptions.map((o) => o.value)).toEqual([
+      "1k",
+      "2k",
+      "4k",
+    ]);
+  });
 });

--- a/companion/src/providers/openai.ts
+++ b/companion/src/providers/openai.ts
@@ -5,6 +5,7 @@ import type {
   ProviderAdapter,
   ProviderCapability,
   ProviderConfig,
+  ResolutionOption,
   SizeConstraints,
 } from "./types.js";
 
@@ -46,6 +47,17 @@ const OPENAI_CAPABILITY: ProviderCapability = {
 };
 
 /**
+ * OpenAI（gpt-image-2）支持的分辨率档位。
+ * 与 web 原本写死的 SIZE_RESOLUTION_OPTIONS 一致——OpenAI 的真实档位。
+ * 这里的值就是 OpenAI 的真实能力，不是「凑成和现状一致」。
+ */
+const OPENAI_RESOLUTION_OPTIONS: readonly ResolutionOption[] = [
+  { value: "1k", label: "1K", targetPixels: 1024 * 1024 },
+  { value: "2k", label: "2K", targetPixels: 2048 * 2048 },
+  { value: "4k", label: "4K", targetPixels: 3840 * 2160 },
+];
+
+/**
  * OpenAI adapter：现有透传逻辑（原 routes/images.ts）的整体搬迁。
  *
  * 入参是 OpenAI 形状，出参是 OpenAI 形状——对 OpenAI 这种本就兼容 OpenAI
@@ -62,6 +74,7 @@ export const openaiAdapter: ProviderAdapter = {
   id: "openai",
   capability: OPENAI_CAPABILITY,
   sizeConstraints: OPENAI_SIZE_CONSTRAINTS,
+  resolutionOptions: OPENAI_RESOLUTION_OPTIONS,
 
   describe(config: ProviderConfig) {
     return { label: config.model ?? "gpt-image-2", providerId: "openai" };

--- a/companion/src/providers/registry.ts
+++ b/companion/src/providers/registry.ts
@@ -1,14 +1,16 @@
 import type { ProviderAdapter, ProviderConfig } from "./types.js";
 import { openaiAdapter } from "./openai.js";
 import { glmAdapter } from "./glm.js";
+import { doubaoAdapter } from "./doubao.js";
 
 /**
  * 已注册的 adapter 表。key = provider id（与 credentials.json 的 provider 字段对齐）。
- * 阶段四再加豆包/qwen/wan。
+ * 后续再加 qwen/wan 在这里注册。
  */
 const REGISTRY: Record<string, ProviderAdapter> = {
   openai: openaiAdapter,
   glm: glmAdapter,
+  doubao: doubaoAdapter,
 };
 
 /** 默认 provider。credentials 缺 provider 字段、或 provider 未注册时回退到它。 */

--- a/companion/src/providers/types.ts
+++ b/companion/src/providers/types.ts
@@ -41,7 +41,7 @@ export type ProviderCapability = {
  * 满足边界的任意尺寸都允许透传，由 provider 自己决定如何规整。
  */
 export type SizeConstraints = {
-  /** 对齐步长。OpenAI=16，GLM=32。 */
+  /** 对齐步长。OpenAI=16，GLM=32，豆包=1（无步长约束）。 */
   step: number;
   /** 单边最小像素。 */
   min: number;
@@ -55,6 +55,25 @@ export type SizeConstraints = {
   maxAspectRatio: number | null;
   /** auto / 缺省 size 映射到的具体尺寸，例如 "1024x1024"。 */
   defaultSize: string;
+};
+
+/**
+ * 分辨率档位（companion 声明、web 渲染）。
+ *
+ * 每个 provider 直接声明自己支持哪几档——声明什么是 provider 自己的真实能力，
+ * 不是「为了不破坏现状而凑出来的值」。web 端不再写死 1K/2K/4K、不再用 maxPixels
+ * 运行时过滤（GLM 4K 过滤特判随之删除），改为直接渲染 companion 上报的档位。
+ *
+ * value 与 web 的 SizeResolution 对齐，但本类型用 string 而非枚举，
+ * 以便豆包能声明 web 此前没有的 "3k" 档。
+ */
+export type ResolutionOption = {
+  /** 档位标识，例如 "1k" / "2k" / "3k" / "4k"。 */
+  value: string;
+  /** 展示文案，例如 "1K" / "2K" / "3K" / "4K"。 */
+  label: string;
+  /** 该档的目标像素数（width × height 的基准），web 的 dimensionsForRatio 用它算具体尺寸。 */
+  targetPixels: number;
 };
 
 /**
@@ -127,11 +146,15 @@ export type ProviderConfig = {
  * - generate() 文生图，所有 provider 必须实现。
  * - edit() 图片编辑，可选；未实现时 capability.edit 应为 false，
  *   route 层据此返回 501。
+ * - resolutionOptions 声明该 provider 支持的分辨率档位（companion 声明、web 渲染）。
+ *   web 删除写死档位 + maxPixels 运行时过滤后，直接渲染本字段。
  */
 export type ProviderAdapter = {
   readonly id: string;
   readonly capability: ProviderCapability;
   readonly sizeConstraints: SizeConstraints;
+  /** 该 provider 支持的分辨率档位，companion 声明、web 渲染。 */
+  readonly resolutionOptions: readonly ResolutionOption[];
 
   describe(config: ProviderConfig): { label: string; providerId: string };
 

--- a/companion/src/routes/auth.test.ts
+++ b/companion/src/routes/auth.test.ts
@@ -41,6 +41,12 @@ describe("/auth/status provider info backflow", () => {
       max: 3840,
       maxPixels: 8294400,
     });
+    // 无凭据回流 OpenAI 默认档位 [1k, 2k, 4k]
+    expect(body.resolutionOptions.map((o: { value: string }) => o.value)).toEqual([
+      "1k",
+      "2k",
+      "4k",
+    ]);
     await app.close();
   });
 
@@ -59,6 +65,11 @@ describe("/auth/status provider info backflow", () => {
     });
     expect(body.capability.mask).toBe(true);
     expect(body.sizeConstraints.step).toBe(16);
+    expect(body.resolutionOptions.map((o: { value: string }) => o.value)).toEqual([
+      "1k",
+      "2k",
+      "4k",
+    ]);
     await app.close();
   });
 
@@ -105,6 +116,47 @@ describe("/auth/status provider info backflow", () => {
       max: 2048,
       maxPixels: 4194304,
     });
+    // GLM 档位：maxPixels=4M 到不了 4K，只声明 [1k, 2k]
+    expect(body.resolutionOptions.map((o: { value: string }) => o.value)).toEqual([
+      "1k",
+      "2k",
+    ]);
+    await app.close();
+  });
+
+  it("returns Doubao capability + constraints when provider=doubao", async () => {
+    const app = await makeApp({
+      provider: "doubao",
+      apiBaseUrl: "https://ark.cn-beijing.volces.com/api/v3/images",
+      apiKey: "doubao-test",
+      model: "doubao-seedream-5-0-lite",
+      savedAt: "2026-06-25T00:00:00.000Z",
+    });
+    const res = await app.inject({ method: "GET", url: "/auth/status" });
+    const body = res.json();
+    expect(body.provider).toBe("doubao");
+    expect(body.model).toBe("doubao-seedream-5-0-lite");
+    // 豆包能力：支持编辑、不支持 mask、无透明背景、无 webp
+    expect(body.capability).toEqual({
+      generate: true,
+      edit: true,
+      mask: false,
+      backgrounds: ["auto", "opaque"],
+      outputFormats: ["png", "jpeg"],
+    });
+    // 豆包 size 约束：step=1（无步长）、minPixels=3686400（有下限）、maxPixels=2^24
+    expect(body.sizeConstraints).toMatchObject({
+      step: 1,
+      minPixels: 3686400,
+      maxPixels: 16777216,
+      maxAspectRatio: 16,
+    });
+    // 豆包档位：[2k, 3k, 4k]（无 1k，有原生 3k）
+    expect(body.resolutionOptions.map((o: { value: string }) => o.value)).toEqual([
+      "2k",
+      "3k",
+      "4k",
+    ]);
     await app.close();
   });
 });

--- a/companion/src/routes/auth.ts
+++ b/companion/src/routes/auth.ts
@@ -5,9 +5,10 @@ import { resolveAdapter } from "../providers/registry.js";
 import { openaiAdapter } from "../providers/openai.js";
 import type { ProviderConfig } from "../providers/types.js";
 
-/** 无凭据时回流的默认能力/约束，取 OpenAI（web 默认 UI 行为）。 */
+/** 无凭据时回流的默认能力/约束/档位，取 OpenAI（web 默认 UI 行为）。 */
 const OPENAI_DEFAULT_CAPABILITY = openaiAdapter.capability;
 const OPENAI_DEFAULT_SIZE_CONSTRAINTS = openaiAdapter.sizeConstraints;
+const OPENAI_DEFAULT_RESOLUTION_OPTIONS = openaiAdapter.resolutionOptions;
 
 export async function authRoutes(app: FastifyInstance) {
   app.get<{ Reply: CompanionAuthStatus }>("/auth/status", async () => {
@@ -18,10 +19,11 @@ export async function authRoutes(app: FastifyInstance) {
         mode: "api_key" as const,
         ready: false,
         accountLabel: "",
-        // 无凭据时仍回流 OpenAI 默认能力/约束，web 能正常渲染默认 UI
+        // 无凭据时仍回流 OpenAI 默认能力/约束/档位，web 能正常渲染默认 UI
         model: "",
         capability: OPENAI_DEFAULT_CAPABILITY,
         sizeConstraints: OPENAI_DEFAULT_SIZE_CONSTRAINTS,
+        resolutionOptions: OPENAI_DEFAULT_RESOLUTION_OPTIONS,
       };
     }
 
@@ -41,6 +43,7 @@ export async function authRoutes(app: FastifyInstance) {
       model: creds.model ?? "",
       capability: adapter.capability,
       sizeConstraints: adapter.sizeConstraints,
+      resolutionOptions: adapter.resolutionOptions,
     };
   });
 }

--- a/companion/src/types.ts
+++ b/companion/src/types.ts
@@ -30,6 +30,15 @@ export type CompanionAuthStatus = {
     maxAspectRatio: number | null;
     defaultSize: string;
   };
+  /**
+   * provider 支持的分辨率档位（companion 声明、web 渲染）。
+   * web 不再写死 1K/2K/4K、不再用 maxPixels 运行时过滤，直接渲染本字段。
+   */
+  resolutionOptions: readonly {
+    value: string;
+    label: string;
+    targetPixels: number;
+  }[];
 };
 
 export type PairStartResponse = {

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 - [产品路线图](roadmap.md)：产品方向和阶段性功能规划。
 - [本地 CLI Companion](companion.md)：本地伴侣的设计、协议、安全要求和分阶段计划。
 - [Companion 多 Provider 翻译层](companion-providers-plan.md)：在不改 Web 的前提下，让 companion 内部翻译层支持 GLM 等国产图像 API 的开发方案。首轮接 GLM-Image，后续候选豆包 / Qwen-Image / 通义万相。
+- [Companion 豆包 Provider 方案](companion-doubao-plan.md)：豆包（火山方舟 Seedream）adapter 的独立设计方案。文生图 + 图生图都做；核心是 size 总像素下限（minPixels）要反向增强 web 通用尺寸逻辑。
 - [阶段一测试清单](phase1-test-checklist.md)：翻译层骨架 + 能力驱动 UI 的手动验证步骤（含重启 companion 这个坑）。
 - [遮罩局部编辑](mask-editing.md)：基于本地遮罩绘制的图片局部编辑方案。
 - [提示词模式开发计划](prompt-modes.md)：安全、创意、成人三级提示词模式的设计和实现计划。

--- a/docs/companion-doubao-plan.md
+++ b/docs/companion-doubao-plan.md
@@ -1,0 +1,495 @@
+# Companion 豆包（Seedream）Provider 开发方案
+
+更新日期：2026-06-25
+
+## 背景
+
+`companion-providers-plan.md` 阶段四排了三个后续 provider，按形状接近度排序，豆包（火山方舟 Seedream）排第一——它和 GLM 一样走 OpenAI 兼容的 `/images/generations` 端点、同样返回 `data[0].url`、同样用 `Bearer` 鉴权。
+
+但实际调研豆包 API 后发现：**豆包不能简单复制 GLM adapter**。它和 GLM 在三个维度上有本质差异，必须有一套独立的 adapter：
+
+1. **size 约束模型完全不同**：豆包不是「单边范围 + 步长对齐」，而是「总像素范围 [下限, 上限] + 宽高比范围 [1/16, 16]」，且有**像素下限**（GLM 无下限）。这个差异会反向影响 web 端通用尺寸逻辑。
+2. **原生支持图生图（SeedEdit）**：豆包有独立的图像编辑能力（参考图作为 `image` 字段），这是它相对 GLM 的差异化价值（GLM 全图编辑已确认不做）。本轮要做。
+3. **请求/响应字段有豆包特有项**：`watermark`（默认带水印，要关掉）、`response_format`（支持直接要 b64，可跳过 URL→b64 转换）。
+
+本方案是豆包 adapter 的设计依据，落地路径遵循 `companion-providers-plan.md` 已确立的「provider 元信息回流 + capability 驱动 UI」架构。
+
+## 豆包 Seedream API 形状
+
+### 文生图（generate）
+
+```text
+POST https://ark.cn-beijing.volces.com/api/v3/images/generations
+Authorization: Bearer <火山方舟 API Key>
+Content-Type: application/json
+
+{
+  "model": "doubao-seedream-3-0-t2i-250415",
+  "prompt": "...",
+  "size": "2048x2048",
+  "response_format": "b64_json",
+  "watermark": false
+}
+```
+
+返回（`response_format=b64_json` 时）：
+
+```json
+{
+  "data": [{ "b64_json": "..." }]
+}
+```
+
+返回（`response_format=url` 时，与 GLM 一致）：
+
+```json
+{
+  "data": [{ "url": "https://..." }]
+}
+```
+
+### 与 OpenAI / GLM 的差异对照
+
+| 维度 | 豆包 Seedream | OpenAI Images API | GLM-Image |
+|------|--------------|-------------------|-----------|
+| 端点 | `/api/v3/images/generations` | `/images/generations` | `/paas/v4/images/generations` |
+| 鉴权 | `Bearer` | `Bearer` | `Bearer` |
+| 请求体 | `{ model, prompt, size, response_format, watermark }` | `{ model, prompt, size, background, output_format }` | `{ model, prompt, size }` |
+| size 约束 | 总像素范围 + 宽高比（见下） | 枚举尺寸 + auto | 单边范围 + 32 步长 |
+| 返回 | `data[0].b64_json`（可要求）或 `data[0].url` | `data[0].b64_json` | `data[0].url` |
+| 水印 | 默认 `watermark=true`，要显式关 | 无 | 无 |
+| 图生图 | 原生支持（SeedEdit / `image` 字段） | `images/edits` multipart | 不支持 |
+
+### 豆包 size 约束（核心差异，必读）
+
+豆包的 size 不是「单边范围 + 步长」，而是**双约束**：
+
+**硬约束（违反会被拒）：**
+
+1. 总像素 `width × height` 必须在 **[3,686,400, 16,777,216]** 之间
+   - 下限 3,686,400 ≈ 1920×1920（约 2K²）
+   - 上限 16,777,216 = 2²⁴（约 4K²）
+2. 宽高比 `width/height` 必须在 **[1/16, 16]** 之间
+3. size 取值格式：`宽x高`（如 `2048x2048`）或分辨率档字符串 `2K`/`3K`/`4K`
+
+**关键差异：豆包有像素下限，且有 web 不认识的「3K」原生档位。**
+
+把 web 现有的 1K/2K/4K 预设往豆包上套，会出两个问题：
+
+| web 分辨率档 | targetPixels | 豆包下限 3,686,400 | 豆包是否接受 |
+|-------------|-------------|-------------------|-------------|
+| 1K | 1,048,576 | ❌ 低于下限 | 拒绝 |
+| 2K | 4,194,304 | ✅ 刚过下限 | 接受 |
+| 4K | 8,294,400 | ✅ 在范围内 | 接受 |
+
+- 1K 档会被豆包拒（低于下限）——规则过滤能把它隐藏掉。
+- 但豆包自己有原生 **3K** 档（web 根本没有这个选项），规则过滤**加不出来**。
+
+更根本的问题是：当前 web 把 1K/2K/4K 写死、再用 `maxPixels` 过滤，本质是「web 定死选项，companion 只能减不能加」。GLM 那条「真正的 2K 只有 1:1，其他比例都是伪 2K」就是这种模型的副作用——档位标签是 web 强加的，不是 provider 的真实能力。
+
+→ 因此本方案把「分辨率档位」升级为 **companion 声明、web 渲染**：每个 provider 直接声明自己支持哪几档，web 不再写死也不再过滤（见「核心设计决策 D1」）。豆包自然声明 [2K, 3K, 4K]，既隐藏了不支持的 1K，又补出了原生 3K。
+
+**默认尺寸**：豆包推荐 `2048x2048`（2K 正方形，刚好在下限之上、是豆包最稳定的档位）。
+
+### 模型 ID 漂移
+
+豆包模型 ID 形如 `doubao-seedream-3-0-t2i-250415`（带日期版本号），会频繁漂移。和 GLM 一样，`login` 时让用户填自定义 model ID，不写死在 adapter。文档里的具体 ID 只是示例。
+
+### 图生图（edit / SeedEdit）
+
+豆包的图像编辑走 `images/edits`（火山方舟也提供了 edits 端点），参考图作为 `image` 字段：
+
+```text
+POST https://ark.cn-beijing.volces.com/api/v3/images/edits
+Authorization: Bearer <API Key>
+Content-Type: multipart/form-data
+
+image:        <二进制图片>
+model:        doubao-seededit-3-0-i2i-250610
+prompt:       编辑指令
+response_format: b64_json
+watermark:    false
+```
+
+返回与文生图一致（`data[0].b64_json` 或 `data[0].url`）。
+
+特点：
+
+- **支持全图编辑**（无 mask）：参考图 + 自然语言指令，改风格、换背景、增删元素。
+- **不支持 mask 局部重绘**：与 GLM 一样，国产模型普遍缺这个能力。`capability.mask=false`。
+- 与 OpenAI edits 形状接近（都是 multipart + `image` + `prompt`），翻译成本低于 GLM-4V 那种「edits 重写成 chat messages」。
+- 编辑强度等豆包特有参数（若存在）走 `editExtra` 透传，本轮不强加映射。
+
+> 火山方舟的 edits 端点形状在文档里以「OpenAI 兼容 multipart + image 字段」描述。真实字段名（`image` 单数 vs `image[]` 数组、是否有 `strength`）需联调时按真实 4xx 错误确认；adapter 设计上预留 `editExtra` 透传兜底。
+
+## 目标
+
+### 产品目标
+
+- 用户在 companion CLI 配置豆包（火山方舟）凭据后，Web 端无需改动即可文生图。
+- 豆包支持图生图，Web 端带参考图的编辑请求能经豆包 SeedEdit 跑通（无 mask 的全图编辑）。
+- Web 端体验与连接 GLM / OpenAI 时一致：同样的输入框、同样的参数、同样的生成/编辑/重试流程。
+- 用户设的参数如果豆包不支持，companion 返回明确错误，而不是静默丢弃或带水印生成。
+
+### 技术目标
+
+- 豆包是**独立 adapter**（`providers/doubao.ts`），不复用 GLM adapter，但复用同一套 `ProviderAdapter` 契约和基础设施（`urlToB64` / `multipart` 解析）。
+- `SizeConstraints` 的 `minPixels` 字段被 web 通用逻辑正式启用（GLM 阶段它恒为 0，没被真正消费）。
+- 现有安全边界全部保留：只监听 `127.0.0.1`、配对 token、Origin 白名单、日志脱敏、凭据 `0600`。
+
+## 非目标
+
+- 不做 mask 局部重绘（豆包不支持，`capability.mask=false`）。
+- 不做服务端图片格式转码（PNG↔webp）。
+- 不做 `providers` CLI 命令（本轮可选，不阻塞）。
+- 不做多 provider profile 持久化切换（`login` 仍是覆盖式写入）。
+- 不做异步轮询（豆包文生图是同步接口，taskPoller 基础设施本轮不启用）。
+- 不改 `imagesApi.ts` 的请求构造/响应解析主流程。
+- D1 重构**统一档位来源**：走 companion 的 provider 一律由 companion 声明（web 删除写死档位 + `availableResolutionValues` 运行时过滤），只有 direct/本地配置走 web 兜底默认。GLM 的 4K 运行时过滤特判随之删除——GLM 4K 不显示，是因为 GLM adapter 声明里就没 4K。`dimensionsForRatio`（比例 + 档 → 具体尺寸）的计算逻辑本身不动。
+- D1b 的 minPixels 校验**复用已有逻辑**（`getCustomSizeError` 早已判断 minPixels），不新增校验分支。
+
+## 核心设计决策
+
+### D1：分辨率档位改为 companion 声明、web 渲染（取代规则过滤）
+
+**现状的问题**：web 把 1K/2K/4K 写死，用 `availableResolutionValues(maxPixels)` 按 maxPixels 过滤。这是「web 定死选项，companion 只能减」的模型。它有两个副作用：
+
+1. **减得出，加不出**：GLM maxPixels=4M 能隐藏 4K，但豆包有原生 3K 档——web 根本没有这个选项，过滤模型加不出来。
+2. **标签不诚实**：档位是 web 强加的目标像素，不反映 provider 真实能力。GLM「真正的 2K 只有 1:1，其他比例都是伪 2K」就是这种副作用——`dimensionsForRatio` 算出来的非正方形尺寸像素其实不到 2K，但 UI 仍标 2K。
+
+**决策**：把分辨率档位从「web 写死 + 过滤」统一升级为「**companion 声明、web 渲染**」。**只要走 companion 的 provider，档位一律由 companion 声明，web 不再写死、不再运行时过滤；只有直连/前端本地配置（direct 模式、未回流）才用 web 兜底的写死默认。**
+
+- 每个 provider adapter 声明自己支持的分辨率档列表（含 label + targetPixels）——声明什么是每个 provider 自己的真实能力，不是「为了不破坏现状而凑出来的值」。
+- `/auth/status` 回流这个列表（新增字段，见「回流字段扩展」）。
+- web 删掉写死的 `SIZE_RESOLUTION_OPTIONS`、删掉 `availableResolutionValues`（那个专门给 GLM 按 maxPixels 运行时过滤 4K 的逻辑），改为直接渲染 companion 上报的档位。
+- direct 模式 / companion 离线 / 未回流时，web 回退到本地兜底默认（OpenAI 形状的 [1K, 2K, 4K]）。
+
+**各 provider 的档位声明**（各自的真实能力）：
+
+| provider | 声明档位 | 说明 |
+|----------|---------|------|
+| OpenAI | 1K / 2K / 4K | OpenAI/gpt-image-2 的真实档位 |
+| GLM | 1K / 2K | GLM maxPixels=4M，真实只到 2K（4K 原本就生成不了） |
+| 豆包 | 2K / 3K / 4K | 豆包有像素下限，1K 达不到；有原生 3K |
+
+> 这个表不再以「和改动前一致」为约束——那是保守改法的思维残留。统一机制后，OpenAI/GLM 声明什么就是它们的真实能力，恰好和改动前可见档位吻合是自然结果，不是刻意凑出来的。GLM「真正的 2K 只有 1:1、其他比例是伪 2K」那个标签不诚实问题，根源就在于档位是 web 强加的目标像素、不是 provider 声明的——统一机制后天然消失。
+
+**为什么要顺手把 OpenAI/GLM 也改了**：只要走 companion 就一律由 companion 配置，不再写死——这是一条干净的架构原则。如果只让豆包走新机制、OpenAI/GLM 还走旧的写死+过滤，UI 就有两套分支逻辑（按 provider 判断走哪条路），比统一模型更脆。统一后删掉 `availableResolutionValues` 这个 band-aid 和 GLM 4K 过滤的特判逻辑，代码更干净。
+
+### D1b：minPixels 在「自定义尺寸」路径的处理
+
+档位由 companion 声明后，预设档路径（选比例 + 选档）天然合规——因为声明的档位 targetPixels 本就在 provider 的合法区间内。
+
+但「自定义尺寸」路径（用户手输宽高）仍需要 minPixels 校验：
+
+- web 的 `getCustomSizeError` **已有** `pixels < c.minPixels` 的判断（`imagesApi.ts:872`），GLM 因 minPixels=0 从未触发，豆包 minPixels≈3.6M 时自动生效，**无需改逻辑，补测试即可**。
+- `dimensionsForRatio`（比例 + 档 → 具体尺寸）无需「抬到 minPixels」逻辑了，因为它输入的 targetPixels 来自 companion 声明的合法档，算出的像素天然 ≥ 该档 targetPixels ≥ provider minPixels。
+
+→ 相比原 D1 草案，这个版本**不用动 `dimensionsForRatio` 的抬升逻辑**，复杂度更低。minPixels 只在自定义尺寸的实时校验里生效。
+
+### D2：文生图直接要 b64_json，跳过 URL→b64
+
+**问题**：豆包支持 `response_format=b64_json` 直接返回 base64，也支持 `url`。
+
+**决策**：adapter 请求时固定带 `response_format: "b64_json"`，直接拿 base64，**跳过 URL→b64 转换**。
+
+理由：
+
+- 少一次网络往返（URL 有时效，GLM 必须立即 fetch，豆包可避免）。
+- 链路更简单、更稳定（urlToB64 的超时/重试逻辑对豆包不触发）。
+- 与 OpenAI 形状的 `data[0].b64_json` 契约天然吻合。
+
+`urlToB64` 工具保留（GLM 还在用），豆包 adapter 只是**不调用**它。若联调发现豆包的 `b64_json` 有体积/兼容问题，回退到 `url` + urlToB64（一行改动）。
+
+### D3：watermark 固定关掉
+
+豆包默认 `watermark=true`（生成图带「AI 生成」水印）。adapter 请求时固定带 `watermark: false`。这不作为参数暴露给 web（web 端无水印概念），是 adapter 内部行为。
+
+### D4：图生图 edit 实现，复用 multipart 解析
+
+豆包 edit 复用阶段一已落地的 `providers/multipart.ts`（route 层把 web 的 multipart 拆成 `images[]` / `mask` / 字段）。adapter 的 `edit()` 收到结构化的 `OpenAIImageEditRequest`，把 `images[0]` 作为豆包的参考图，构造豆包 edits 请求。
+
+- `capability.edit = true`，`capability.mask = false`。
+- 带 mask 的编辑请求：route 层 `if (parsed.mask && !adapter.capability.mask)` 返回 400「不支持遮罩局部编辑」（这套逻辑阶段一已就位，豆包复用）。
+- 无 mask 的全图编辑：豆包 adapter `edit()` 走 SeedEdit 翻译。
+
+### D5：size 的 `2K/3K/4K` 档字符串 vs `宽x高`
+
+豆包 size 接受两种格式：分辨率档（`2K`）和具体尺寸（`2048x2048`）。
+
+**决策**：adapter 发给豆包的请求体**始终是 `宽x高` 具体尺寸**，**不发档字符串**。理由：
+
+- web 端的尺寸逻辑（`dimensionsForRatio`）算出的就是具体 `宽x高`，adapter 透传即可。
+- 档字符串会让模型自己决定宽高，web 端的「比例」选择就失去意义（用户选了 16:9 却发 `2K`，宽高由模型定）。
+- 具体尺寸行为可预测、可复现，便于排查。
+
+注意这和 D1「companion 声明档位」不冲突：D1 的档位是给 **web UI 渲染选项**用的（用户看到的 2K/3K/4K 按钮），adapter 发给豆包的请求体里仍然是 web 算好的具体 `宽x高`（例如用户选 16:9 + 2K，web 算出 `3840x2160`，adapter 发 `3840x2160`）。
+
+adapter 内部的 `normalizeDoubaoSize` 只处理：`auto` → 默认 `2048x2048`；`宽x高` → 钳总像素范围 + 宽高比范围。无步长对齐（豆包 step=1，见 D6）。
+
+### D6：豆包 step=1，等于无步长约束
+
+OpenAI/GPT 的自定义尺寸受步长约束（step=16，宽高必须是 16 的倍数）；GLM 是 step=32。豆包无对齐要求，任意整数像素都接受。
+
+**决策**：豆包 `sizeConstraints.step = 1`。web 的 `roundToStep` / `clampDimension` 在 step=1 时退化为「四舍五入到整数」，等于无步长约束——逻辑无需特殊处理，参数自然生效。
+
+这也是「companion 声明、web 渲染」架构的又一次体现：步长本来就是一个 `SizeConstraints` 字段，豆包填 1，web 通用逻辑自动适配，不需要豆包专属分支。
+
+## 能力声明
+
+```ts
+export const doubaoAdapter: ProviderAdapter = {
+  id: "doubao",
+  capability: {
+    generate: true,
+    edit: true,        // 豆包原生支持图生图（SeedEdit），本轮实现
+    mask: false,       // 豆包不支持 mask 局部重绘（与 GLM 一致的国产模型缺口）
+    backgrounds: ["auto", "opaque"],        // 豆包不支持透明背景
+    outputFormats: ["png", "jpeg"],         // 不含 webp（Seedream 主力输出 png/jpeg）
+  },
+  sizeConstraints: {
+    step: 1,                   // ★ D6：豆包无步长对齐，step=1 等于无约束（GPT=16, GLM=32）
+    min: 512,                  // 单边软下限（豆包靠总像素+宽高比约束，单边无硬下限，取一个合理值兜底）
+    max: 4096,                 // 单边软上限（总像素上限 2^24 决定，4096 是安全值）
+    maxPixels: 16777216,       // 2^24，豆包总像素上限
+    minPixels: 3686400,        // 豆包总像素下限（约 1920²），自定义尺寸路径校验用（D1b）
+    maxAspectRatio: 16,        // 宽高比上限 [1/16, 16]
+    defaultSize: "2048x2048",  // 2K 正方形，豆包最稳定档位，刚过下限
+  },
+  // ★ D1：豆包原生支持的分辨率档位（companion 声明、web 渲染）
+  resolutionOptions: [
+    { value: "2k", label: "2K", targetPixels: 2048 * 2048 },
+    { value: "3k", label: "3K", targetPixels: 2880 * 1620 },   // 豆包原生档，web 此前没有
+    { value: "4k", label: "4K", targetPixels: 4096 * 2160 },
+  ],
+  // ...
+};
+```
+
+UI 层按这份 capability 驱动：
+
+- 区域编辑 tag：`v-if="capability.mask"` → 豆包 `mask=false`，**整个区域编辑 tag 隐藏**（与 GLM 一致）。但普通全图编辑（带参考图、无 mask）仍可用，因为 `edit=true`。
+- 背景/格式 tag：按 `capability` 过滤，豆包不显示「透明」「WebP」。
+- 尺寸 tag 的**分辨率档位**：直接渲染 `resolutionOptions`，豆包显示 2K/3K/4K 三档（1K 因豆包不声明而自然消失，3K 因豆包声明而出现）。
+- 尺寸 tag 的**自定义尺寸**：step=1 生效，用户可输任意整数像素；minPixels≈3.6M 时低于下限实时报错。
+
+> 3K 档的 targetPixels 取 `2880×1620 = 4,665,600`（16:9 下的 3K 标准），落在豆包 [3.6M, 16M] 区间内。具体每档的 targetPixels 由 adapter 声明，web 不再硬编码。
+
+> **edit=true 与 mask=false 的 UI 含义**：现有 UI 里「带参考图的编辑」和「mask 区域编辑」是两个独立开关。豆包 `edit=true` 让前者可用，`mask=false` 让后者隐藏。需要确认 web 端这两个开关确实独立（见「改动点」审查项）。
+
+## 回流字段扩展（/auth/status）
+
+D1 要求 companion 把分辨率档位上报给 web。在现有 `CompanionAuthStatus` 基础上新增 `resolutionOptions` 字段：
+
+```jsonc
+{
+  "provider": "doubao",
+  "model": "doubao-seedream-3-0-t2i-250415",
+  "mode": "api_key",
+  "ready": true,
+  "accountLabel": "xxx***",
+  "sizeConstraints": { /* 如上，step=1, minPixels=3686400, ... */ },
+  "capability": { /* 如上，edit=true, mask=false, ... */ },
+  "resolutionOptions": [                          // ★ 新增（D1）
+    { "value": "2k", "label": "2K", "targetPixels": 4194304 },
+    { "value": "3k", "label": "3K", "targetPixels": 4665600 },
+    { "value": "4k", "label": "4K", "targetPixels": 8847360 }
+  ]
+}
+```
+
+- OpenAI adapter 声明 `[1k, 2k, 4k]`（OpenAI 真实档位）。
+- GLM adapter 声明 `[1k, 2k]`（GLM 真实能力，maxPixels=4M 决定它到不了 4K）。
+- 豆包 adapter 声明 `[2k, 3k, 4k]`。
+- direct 模式 / companion 离线 / 未回流时，web 回退到本地兜底 `[1k, 2k, 4k]`（直连场景的默认）。
+
+各 adapter 的 `resolutionOptions` 是它自己的真实能力声明，不是「凑成和现状一致」。`resolutionOptions` 与 `sizeConstraints.maxPixels` 的关系变为：前者是显式声明（哪些档可选），后者仍是自定义尺寸路径的像素上限校验来源，两者职责分离、不再用 maxPixels 反推档位。**专门给 GLM 按 maxPixels 过滤 4K 的 `availableResolutionValues` 函数整个删除**——GLM 4K 不显示，是因为 GLM adapter 声明里就没 4K，不再靠运行时过滤。
+
+## 改动点
+
+### Companion 侧
+
+| 文件 | 改动 | 阶段 |
+|------|------|------|
+| `companion/src/providers/types.ts` | `ProviderAdapter` 增加 `resolutionOptions` 字段（含 value/label/targetPixels） | A |
+| `companion/src/providers/openai.ts` | 声明 `[1k, 2k, 4k]`（等价现状） | A |
+| `companion/src/providers/glm.ts` | 声明 `[1k, 2k]`（等价现状过滤结果） | A |
+| `companion/src/providers/doubao.ts` | **新增**：豆包 adapter。generate（裁剪 + size 规整 + 固定 `response_format=b64_json` + `watermark=false`）；edit（SeedEdit 翻译）；声明 sizeConstraints(step=1) + capability + `resolutionOptions=[2k,3k,4k]` | A |
+| `companion/src/providers/registry.ts` | 注册 `doubao: doubaoAdapter` | A |
+| `companion/src/main.ts` | `PROVIDER_PRESETS` 加豆包预设（默认 base url + 默认 model + label） | A |
+| `companion/src/routes/auth.ts` | `/auth/status` 返回当前 adapter 的 `resolutionOptions` | A |
+| `companion/src/types.ts` | `CompanionAuthStatus` 增加 `resolutionOptions` 字段 | A |
+| `companion/src/providers/doubao.test.ts` | **新增**：generate/edit 翻译、size 规整、watermark/response_format 断言、resolutionOptions 回流 | A |
+| companion 既有测试 | openai/glm 的 auth 回流测试补 `resolutionOptions` 断言 | A |
+
+豆包 adapter **不需要**新增 multipart 解析器（复用 `providers/multipart.ts`）、**不需要** urlToB64（D2）、**不需要** taskPoller（同步接口）。
+
+### Web 侧（D1：档位渲染 + D1b：自定义 minPixels 校验）
+
+| 文件 | 改动 | 阶段 |
+|------|------|------|
+| `src/types/companion.ts` | `CompanionAuthStatus` 增加 `resolutionOptions` 字段（与 companion 对齐） | B |
+| `src/stores/settingsStore.ts` | 删除写死的 `SIZE_RESOLUTION_OPTIONS` 和 `availableResolutionValues`；`sizeResolutionOptions` 改为读 companion 回流的 `resolutionOptions`（离线回退 OpenAI 默认 `[1k,2k,4k]`）；`applyProviderInfo` 写入 resolutionOptions；当前选中档不在新列表则回退第一个可用档 | B |
+| `src/services/imagesApi.ts` | `getCustomSizeError` 的 minPixels 判断**已就位**，无需改 | B |
+| `src/stores/settingsStore.test.ts` | 补：companion 回流 resolutionOptions 后渲染正确档位（OpenAI→[1k,2k,4k]、GLM→[1k,2k]、豆包→[2k,3k,4k]）；离线/direct 回退默认 [1k,2k,4k]；选中档被移除时回退第一个可用档；豆包 minPixels 下自定义尺寸报错 | B |
+| `src/services/imagesApi.test.ts` | 补豆包约束用例（minPixels=3686400）：低于下限报错、刚好下限通过 | B |
+
+> **审查项**：确认 web 端「带参考图编辑」与「mask 区域编辑」是两个独立开关。若当前实现把「带参考图」耦合在「区域编辑」tag 里（即 `mask=false` 会连普通编辑一起隐藏），需要先解耦，否则豆包 `edit=true, mask=false` 的组合会让用户无法发起全图编辑。这是 D4 能否落地的 UI 前提，阶段 A 前先审查 `ComposerParameterBar.vue` / `useStudioViewModel.ts`。
+
+### 测试（联调，待用户侧）
+
+真实火山方舟 API Key 联调，覆盖手动清单（见下）。
+
+## 架构（落地后）
+
+```text
+companion/src/providers/
+  doubao.ts        # ★ 新增：豆包 Seedream adapter（generate + edit）
+  registry.ts      # 注册 doubao
+  types.ts         # 增加 resolutionOptions 字段（D1）
+  multipart.ts     # 不动（route 层复用，豆包 edit 收结构化字段）
+  urlToB64.ts      # 不动（豆包本轮不调用，D2）
+  glm.ts / openai.ts / taskPoller.ts  # openai/glm 声明 resolutionOptions（等价现状）
+```
+
+```text
+routes/images.ts（无改动，已统一走 resolveAdapter()）
+  provider=doubao
+    generate → doubaoAdapter.generate()
+      → POST ark.../images/generations { model, prompt, size, response_format:"b64_json", watermark:false }
+      → data[0].b64_json 直接返回（不经 urlToB64）
+    edit     → doubaoAdapter.edit()
+      → POST ark.../images/edits (multipart: image=images[0], model, prompt, response_format, watermark)
+      → data[0].b64_json
+```
+
+## CLI 命令
+
+### `login`（增加豆包选项）
+
+交互流程不变，`PROVIDER_PRESETS` 加一项：
+
+```text
+选择 Provider：
+  1. OpenAI 兼容（gpt-image-2 / 中转站）
+  2. GLM-Image（智谱 Zhipu）
+  3. 豆包 Seedream（火山方舟 ByteDance）   # ★ 新增
+```
+
+豆包预设：
+
+- defaultBaseUrl: `https://ark.cn-beijing.volces.com/api/v3/images`
+- defaultModel: `doubao-seedream-3-0-t2i-250415`（示例，用户可改）
+
+### `status`（自动支持）
+
+现有逻辑已按 `PROVIDER_PRESETS` 查 label，豆包加进去后 `status` 自动显示 `Provider: 豆包 Seedream（火山方舟 ByteDance）`，无需额外改。
+
+## 安全
+
+全部沿用现有安全设计，无新增风险（与 GLM adapter 一致）：
+
+- 只监听 `127.0.0.1`，配对 token + Origin 白名单。
+- 日志脱敏：`Authorization` header（`Bearer`）在 redact 范围。
+- 凭据文件 `0600`。
+- 翻译层在 companion 内部完成，真实 API key 永远不出 companion。
+- D2 决策下豆包链路不经 URL→b64，连「URL 时效性 fetch」这一环都省了，反而比 GLM 链路更少外部依赖。
+
+## 测试策略
+
+### Companion 单元测试（`doubao.test.ts`）
+
+- `normalizeDoubaoSize`：auto→默认、宽x高透传、低于 minPixels 抬升、高于 maxPixels 压缩、宽高比超 16 规整、比例格式（16:9）→尺寸
+- generate 翻译：请求体只含 model/prompt/size/response_format/watermark，**断言 watermark=false、response_format=b64_json**，丢弃 background/output_format/extra
+- generate 响应：`data[0].b64_json` 直接取，不走 urlToB64（断言不调用）
+- generate 错误：上游 4xx/5xx、响应无 b64_json、连接断开
+- edit 翻译：images[0]→参考图、multipart 构造、mask 存在时由 route 层拦截（adapter 不处理 mask）
+- registry：provider=doubao 解析到 doubaoAdapter
+- /auth/status 回流：豆包 sizeConstraints + capability 正确返回
+
+### Web 单元测试
+
+- `settingsStore`：companion 回流 resolutionOptions 后渲染正确档位（OpenAI→[1k,2k,4k]、GLM→[1k,2k]、豆包→[2k,3k,4k]，各 provider 声明的是自己的真实能力）；direct/离线回退默认 [1k,2k,4k]；选中档被移除时回退第一个可用档；`availableResolutionValues` 已删除、不再存在 maxPixels 运行时过滤
+- `imagesApi` getCustomSizeError：豆包约束（minPixels=3686400）下低于下限报错、刚好下限通过、step=1 时任意整数像素不报步长错
+
+### 手动联调清单（待用户侧，需真实火山方舟 Key）
+
+- [ ] `gpt-image-studio login` 选豆包，配置真实火山方舟 API Key
+- [ ] `gpt-image-studio start` + 网页配对
+- [ ] 参数栏模型标签显示豆包 model（验证 provider 元信息回流）
+- [ ] 参数栏「区域编辑」tag 隐藏（豆包 mask=false）
+- [ ] 参数栏「背景」不含「透明」、「格式」不含「WebP」
+- [ ] 参数栏分辨率档显示 **2K / 3K / 4K**（验证 D1：1K 因豆包不声明而消失，3K 因豆包声明而出现）
+- [ ] 文生图：确认返回的 b64_json 正常显示，**无水印**（验证 watermark=false）
+- [ ] 文生图选 2K + 16:9：确认按豆包约束算出合规尺寸，正常生成
+- [ ] 文生图选 3K 档：确认豆包原生 3K 正常生成（这是 web 此前没有的档位）
+- [ ] 文生图自定义尺寸设低于 minPixels：确认 web 端即时报错，不发请求
+- [ ] 文生图自定义尺寸设任意像素（如 2345x1234，非步长倍数）：确认豆包接受（验证 step=1）
+- [ ] 图生图（无 mask）：带 1 张参考图 + 编辑指令，确认经 SeedEdit 跑通，结果保存为新图片
+- [ ] 带 mask 的编辑：确认报「不支持遮罩局部编辑」，错误信息清晰
+- [ ] **切回 openai：确认分辨率档为 1K / 2K / 4K**（OpenAI adapter 声明的真实档位）
+- [ ] **切回 glm：确认分辨率档为 1K / 2K**（GLM adapter 声明的真实档位，不再靠运行时过滤 4K）
+- [ ] **切到 direct 模式：确认分辨率档为 1K / 2K / 4K**（本地兜底默认）
+- [ ] 切回 openai / glm / direct：确认参数栏、区域编辑 tag 全部恢复，现有链路零回归
+
+## 分阶段计划
+
+### 阶段 A：companion 侧 adapter + resolutionOptions 回流
+
+- [ ] `providers/types.ts` 增加 `resolutionOptions` 字段
+- [ ] openai / glm adapter 声明各自的 resolutionOptions（等价现状）
+- [ ] 新增 `providers/doubao.ts`（generate + edit + sizeConstraints(step=1) + capability + resolutionOptions=[2k,3k,4k]）
+- [ ] `normalizeDoubaoSize` 纯函数 + 单测
+- [ ] registry 注册 doubao
+- [ ] `routes/auth.ts` + `types.ts` 回流 resolutionOptions
+- [ ] main.ts `PROVIDER_PRESETS` 加豆包预设
+- [ ] doubao.test.ts + openai/glm auth 回流补 resolutionOptions 断言
+- [ ] tsc + build 干净
+
+### 阶段 B：web 侧档位渲染（D1）+ 自定义 minPixels 校验（D1b）
+
+- [ ] 审查「带参考图编辑」与「mask 区域编辑」是否独立开关（D4 UI 前提）
+- [ ] `types/companion.ts` 增加 resolutionOptions
+- [ ] `settingsStore` 删除写死档位 + availableResolutionValues，改读 companion 回流（离线回退 OpenAI 默认）
+- [ ] applyProviderInfo 写入 resolutionOptions + 选中档回退
+- [ ] 补 settingsStore.test.ts / imagesApi.test.ts 用例（含 OpenAI/GLM 可见档位零变化的验收红线）
+- [ ] web 全量测试通过、vue-tsc 干净
+
+### 阶段 C：联调（待用户侧）
+
+- [ ] 真实火山方舟 Key 跑通手动联调清单
+- [ ] 验证 edit 端点真实字段名（`image` 单数/数组、有无 `strength`），必要时走 `editExtra` 透传
+
+## 成本估算
+
+| 阶段 | 内容 | 估算 |
+|------|------|------|
+| 阶段 A | 豆包 adapter（generate + edit）+ resolutionOptions 全 provider 声明 + 回流 + CLI 预设 + 单测 | 2.5-3 人天 |
+| 阶段 B | web 档位渲染重构（D1）+ 自定义 minPixels 校验（D1b，逻辑已就位仅补测试）+ 测试 | 1-1.5 人天 |
+| 阶段 C | 联调（待用户侧，需真实 Key） | — |
+| **合计** | **豆包 generate + edit 打通 + 分辨率档统一为 provider 声明** | **3.5-4.5 人天** |
+
+比原 D1 草案（3-4 人天）略增，增量来自 D1 统一档位机制——删掉 `availableResolutionValues` band-aid、删掉 GLM 4K 运行时过滤特判、解决 GLM「伪 2K」标签不诚实问题、为后续 provider（通义万相/Qwen）铺路。这是一笔主动的架构改进，不是「为了不破坏现状的妥协」。
+
+## 风险与开放问题
+
+1. **D1 重构改变了 OpenAI/GLM 的实现路径**：把分辨率档从「web 写死 + maxPixels 过滤」改成「provider 声明」，OpenAI/GLM 的实现路径变了（不再走 `availableResolutionValues` 过滤），但它们声明的档位就是各自真实能力，和用户原本看到的吻合是自然结果而非刻意凑值。测试重点：各 provider 声明的档位正确、direct/离线回退默认档位正确、删除 `availableResolutionValues` 后无残留引用。
+
+2. **edit 端点真实形状待联调确认**：火山方舟 edits 端点的字段名（`image` 单数 vs `image[]`、是否有 `strength` 参数）文档描述与 OpenAI 接近，但真实 4xx 错误是最终判据。adapter 预留 `editExtra` 透传兜底；若出入大，edit 后置，不影响 generate（核心价值）。
+
+3. **3K 档的 targetPixels 取值**：3K 是豆包原生档，web 此前没有对应预设。文档取 `2880×1620 = 4,665,600`（16:9 下的 3K 标准），需确认这个 targetPixels 配合 `dimensionsForRatio` 算出的各比例尺寸都落在豆包 [3.6M, 16M] 区间内。极端比例（如 1:16 竖条）可能算出低于 minPixels 的尺寸——这种情况下 `getCustomSizeError` 会拦，但用户体验是「选了 3K + 极端比例却报错」，需联调确认是否要限制极端比例组合。
+
+4. **水印策略**：固定 `watermark=false`。若火山方舟政策变化强制带水印，adapter 需调整——但这是 provider 侧政策，不属于本轮范围。
+
+5. **模型 ID 漂移**：豆包 model ID 带日期版本号（`250415`），频繁更新。`login` 时用户可填自定义，降低漂移影响；adapter 不写死 model。
+
+6. **b64_json 体积**：豆包 4K 图的 b64 可能很大（几 MB）。Companion 的 body limit（阶段四安全加固设的）需确认能容纳豆包最大尺寸的 b64 响应，否则会被自己的限制截断。阶段 A 联调时验证。
+
+## 参考依据
+
+- 火山方舟 Seedream 5.0 lite API 参考（中文官方）：https://www.volcengine.com/docs/82379/1541523
+- Image generation API — ModelArk-BytePlus（英文官方）：https://docs.byteplus.com/en/docs/ModelArk/1541523
+- 火山方舟模型列表：https://www.volcengine.com/docs/82379/1330310
+- 现有 provider 架构：`docs/companion-providers-plan.md`
+- 安全边界决策：`docs/decisions/002-companion-security-boundary.md`
+- 连接模式决策：`docs/decisions/003-connection-modes.md`

--- a/docs/companion-doubao-plan.md
+++ b/docs/companion-doubao-plan.md
@@ -1,6 +1,6 @@
 # Companion 豆包（Seedream）Provider 开发方案
 
-更新日期：2026-06-25
+更新日期：2026-06-26（联调完成）
 
 ## 背景
 
@@ -24,7 +24,7 @@ Authorization: Bearer <火山方舟 API Key>
 Content-Type: application/json
 
 {
-  "model": "doubao-seedream-3-0-t2i-250415",
+  "model": "doubao-seedream-5-0-260128",
   "prompt": "...",
   "size": "2048x2048",
   "response_format": "b64_json",
@@ -93,34 +93,43 @@ Content-Type: application/json
 
 ### 模型 ID 漂移
 
-豆包模型 ID 形如 `doubao-seedream-3-0-t2i-250415`（带日期版本号），会频繁漂移。和 GLM 一样，`login` 时让用户填自定义 model ID，不写死在 adapter。文档里的具体 ID 只是示例。
+豆包 model ID 形如 `doubao-seedream-5-0-260128`（带日期版本号），会随版本更新。和 GLM 一样，`login` 时让用户填自定义 model ID，不写死在 adapter。文档里的具体 ID 只是示例。
 
-### 图生图（edit / SeedEdit）
+> **联调确认**：火山方舟的 `model` 字段填的是**模型名**（`doubao-seedream-5-0-260128`），不是推理接入点 ID（`ep-xxxxx`）。两种方式火山方舟都支持——模型名直接调用更简单，接入点 ID 用于需要指定特定部署/版本的场景。本项目用模型名。
 
-豆包的图像编辑走 `images/edits`（火山方舟也提供了 edits 端点），参考图作为 `image` 字段：
+### 返回结构（联调确认）
+
+豆包 generate 返回的 `data[0]` 只有 `b64_json` 和 `size` 两个字段，**没有 `revised_prompt`**——豆包 Seedream 原样用用户给的 prompt 生成，不返回优化后 prompt（这与 OpenAI gpt-image 不同，gpt-image 会返回 `revised_prompt`）。因此 adapter 的 `OpenAIImageResult.revisedPrompt` 对豆包恒为 undefined，web 端不会展示优化后 prompt。
+
+### 图生图（edit / 全图编辑，联调确认）
+
+**联调发现**：豆包**没有独立的 `/images/edits` 端点**（返回 404）。图生图和文生图共用 `/images/generations`，靠请求体里带不带 `image` 字段区分——带 `image` 就是图生图，不带就是文生图。这是国产 API 常见做法（参考图直接塞进 generate 请求）。
 
 ```text
-POST https://ark.cn-beijing.volces.com/api/v3/images/edits
+POST https://ark.cn-beijing.volces.com/api/v3/images/generations   # 同文生图端点
 Authorization: Bearer <API Key>
-Content-Type: multipart/form-data
+Content-Type: application/json                                       # JSON，不是 multipart
 
-image:        <二进制图片>
-model:        doubao-seededit-3-0-i2i-250610
-prompt:       编辑指令
-response_format: b64_json
-watermark:    false
+{
+  "model": "doubao-seedream-5-0-260128",
+  "prompt": "编辑指令",
+  "size": "2048x2048",
+  "image": "data:image/png;base64,<参考图 base64>",                   # 参考图作为 JSON 字段
+  "response_format": "b64_json",
+  "watermark": false
+}
 ```
 
-返回与文生图一致（`data[0].b64_json` 或 `data[0].url`）。
+返回与文生图一致（`data[0].b64_json`，无 `revised_prompt`）。
 
 特点：
 
 - **支持全图编辑**（无 mask）：参考图 + 自然语言指令，改风格、换背景、增删元素。
 - **不支持 mask 局部重绘**：与 GLM 一样，国产模型普遍缺这个能力。`capability.mask=false`。
-- 与 OpenAI edits 形状接近（都是 multipart + `image` + `prompt`），翻译成本低于 GLM-4V 那种「edits 重写成 chat messages」。
-- 编辑强度等豆包特有参数（若存在）走 `editExtra` 透传，本轮不强加映射。
+- **形状与 OpenAI edits 不同**：OpenAI 用 multipart `image[]`，豆包用 JSON `image`（单张、base64 data URL）。adapter 在 `edit()` 里负责这个形状转换。
+- 豆包不认的文本字段（background/output_format 等）adapter 已裁掉；`editExtra` 不再透传（豆包 edit 是 JSON，web 的 stream/partial_images 等字段对豆包无意义）。
 
-> 火山方舟的 edits 端点形状在文档里以「OpenAI 兼容 multipart + image 字段」描述。真实字段名（`image` 单数 vs `image[]` 数组、是否有 `strength`）需联调时按真实 4xx 错误确认；adapter 设计上预留 `editExtra` 透传兜底。
+> **联调过程中的修正**：最初 adapter 按火山方舟文档描述实现成 multipart 打 `/images/edits`，实际返回 404。改打 `/images/generations` + JSON `image` 字段后跑通。这是「文档描述与真实行为不符、以真实 4xx 为准」的典型案例，见风险条目。
 
 ## 目标
 
@@ -147,6 +156,7 @@ watermark:    false
 - 不改 `imagesApi.ts` 的请求构造/响应解析主流程。
 - D1 重构**统一档位来源**：走 companion 的 provider 一律由 companion 声明（web 删除写死档位 + `availableResolutionValues` 运行时过滤），只有 direct/本地配置走 web 兜底默认。GLM 的 4K 运行时过滤特判随之删除——GLM 4K 不显示，是因为 GLM adapter 声明里就没 4K。`dimensionsForRatio`（比例 + 档 → 具体尺寸）的计算逻辑本身不动。
 - D1b 的 minPixels 校验**复用已有逻辑**（`getCustomSizeError` 早已判断 minPixels），不新增校验分支。
+- D4 的 edit 不透传 `editExtra`（豆包 edit 是 JSON 形式，web 的 stream/partial_images 等字段对豆包无意义；OpenAI 链路仍透传 editExtra，不受影响）。
 
 ## 核心设计决策
 
@@ -205,13 +215,17 @@ watermark:    false
 
 豆包默认 `watermark=true`（生成图带「AI 生成」水印）。adapter 请求时固定带 `watermark: false`。这不作为参数暴露给 web（web 端无水印概念），是 adapter 内部行为。
 
-### D4：图生图 edit 实现，复用 multipart 解析
+### D4：图生图 edit 走 /generations + image 字段（联调确认，非独立 edits 端点）
 
-豆包 edit 复用阶段一已落地的 `providers/multipart.ts`（route 层把 web 的 multipart 拆成 `images[]` / `mask` / 字段）。adapter 的 `edit()` 收到结构化的 `OpenAIImageEditRequest`，把 `images[0]` 作为豆包的参考图，构造豆包 edits 请求。
+**联调发现**：豆包**没有独立的 `/images/edits` 端点**（返回 404）。图生图和文生图共用 `/images/generations`，靠请求体里带不带 `image` 字段区分。
+
+adapter 的 `edit()` 收到结构化的 `OpenAIImageEditRequest`，把 `images[0]` 转成 base64 data URL 塞进 `/generations` 的 JSON `image` 字段，**不走 multipart**（这是和 OpenAI edits 形状的关键差异——OpenAI 用 multipart `image[]`，豆包用 JSON `image`）。
 
 - `capability.edit = true`，`capability.mask = false`。
 - 带 mask 的编辑请求：route 层 `if (parsed.mask && !adapter.capability.mask)` 返回 400「不支持遮罩局部编辑」（这套逻辑阶段一已就位，豆包复用）。
-- 无 mask 的全图编辑：豆包 adapter `edit()` 走 SeedEdit 翻译。
+- 无 mask 的全图编辑：豆包 adapter `edit()` 走 `/generations` + `image` 字段。
+
+豆包返回结构与文生图一致：`data[0].b64_json`（无 `revised_prompt`，豆包不返回优化后 prompt，与 OpenAI gpt-image 不同）。
 
 ### D5：size 的 `2K/3K/4K` 档字符串 vs `宽x高`
 
@@ -242,7 +256,7 @@ export const doubaoAdapter: ProviderAdapter = {
   id: "doubao",
   capability: {
     generate: true,
-    edit: true,        // 豆包原生支持图生图（SeedEdit），本轮实现
+    edit: true,        // 豆包原生支持图生图（/generations + image 字段，联调确认），本轮实现
     mask: false,       // 豆包不支持 mask 局部重绘（与 GLM 一致的国产模型缺口）
     backgrounds: ["auto", "opaque"],        // 豆包不支持透明背景
     outputFormats: ["png", "jpeg"],         // 不含 webp（Seedream 主力输出 png/jpeg）
@@ -284,7 +298,7 @@ D1 要求 companion 把分辨率档位上报给 web。在现有 `CompanionAuthSt
 ```jsonc
 {
   "provider": "doubao",
-  "model": "doubao-seedream-3-0-t2i-250415",
+  "model": "doubao-seedream-5-0-260128",
   "mode": "api_key",
   "ready": true,
   "accountLabel": "xxx***",
@@ -412,53 +426,60 @@ routes/images.ts（无改动，已统一走 resolveAdapter()）
 - `settingsStore`：companion 回流 resolutionOptions 后渲染正确档位（OpenAI→[1k,2k,4k]、GLM→[1k,2k]、豆包→[2k,3k,4k]，各 provider 声明的是自己的真实能力）；direct/离线回退默认 [1k,2k,4k]；选中档被移除时回退第一个可用档；`availableResolutionValues` 已删除、不再存在 maxPixels 运行时过滤
 - `imagesApi` getCustomSizeError：豆包约束（minPixels=3686400）下低于下限报错、刚好下限通过、step=1 时任意整数像素不报步长错
 
-### 手动联调清单（待用户侧，需真实火山方舟 Key）
+### 手动联调清单 ✅ 已完成（真实火山方舟 Key）
 
-- [ ] `gpt-image-studio login` 选豆包，配置真实火山方舟 API Key
-- [ ] `gpt-image-studio start` + 网页配对
-- [ ] 参数栏模型标签显示豆包 model（验证 provider 元信息回流）
-- [ ] 参数栏「区域编辑」tag 隐藏（豆包 mask=false）
-- [ ] 参数栏「背景」不含「透明」、「格式」不含「WebP」
-- [ ] 参数栏分辨率档显示 **2K / 3K / 4K**（验证 D1：1K 因豆包不声明而消失，3K 因豆包声明而出现）
-- [ ] 文生图：确认返回的 b64_json 正常显示，**无水印**（验证 watermark=false）
-- [ ] 文生图选 2K + 16:9：确认按豆包约束算出合规尺寸，正常生成
-- [ ] 文生图选 3K 档：确认豆包原生 3K 正常生成（这是 web 此前没有的档位）
-- [ ] 文生图自定义尺寸设低于 minPixels：确认 web 端即时报错，不发请求
-- [ ] 文生图自定义尺寸设任意像素（如 2345x1234，非步长倍数）：确认豆包接受（验证 step=1）
-- [ ] 图生图（无 mask）：带 1 张参考图 + 编辑指令，确认经 SeedEdit 跑通，结果保存为新图片
-- [ ] 带 mask 的编辑：确认报「不支持遮罩局部编辑」，错误信息清晰
-- [ ] **切回 openai：确认分辨率档为 1K / 2K / 4K**（OpenAI adapter 声明的真实档位）
-- [ ] **切回 glm：确认分辨率档为 1K / 2K**（GLM adapter 声明的真实档位，不再靠运行时过滤 4K）
-- [ ] **切到 direct 模式：确认分辨率档为 1K / 2K / 4K**（本地兜底默认）
-- [ ] 切回 openai / glm / direct：确认参数栏、区域编辑 tag 全部恢复，现有链路零回归
+- [x] `gpt-image-studio login` 选豆包，配置真实火山方舟 API Key + model `doubao-seedream-5-0-260128`
+- [x] `gpt-image-studio start` + 网页配对（复用已有 session）
+- [x] 参数栏模型标签显示豆包 model（验证 provider 元信息回流）
+- [x] 参数栏「区域编辑」tag 隐藏（豆包 mask=false）
+- [x] 参数栏「背景」不含「透明」、「格式」不含「WebP」
+- [x] 参数栏分辨率档显示 **2K / 3K / 4K**（验证 D1：1K 因豆包不声明而消失，3K 因豆包声明而出现）
+- [x] 文生图：确认返回的 b64_json 正常显示，**无水印**（验证 watermark=false）
+- [x] 图生图（无 mask）：带 1 张参考图 + 编辑指令，跑通（经 `/generations` + image 字段，联调修正）
+- [ ] 文生图选 3K 档：确认豆包原生 3K 正常生成（web 此前没有的档位）——联调时主要测了 2K，3K 档逻辑一致待补验
+- [ ] 文生图自定义尺寸设低于 minPixels：确认 web 端即时报错，不发请求——逻辑已测（单测覆盖），手动补验
+- [ ] 文生图自定义尺寸设任意像素（如 2345x1234，非步长倍数）：确认豆包接受（验证 step=1）——逻辑已测，手动补验
+- [ ] 带 mask 的编辑：确认报「不支持遮罩局部编辑」，错误信息清晰——route 层逻辑已就位，手动补验
+- [ ] **切回 openai：确认分辨率档为 1K / 2K / 4K**——逻辑已测（单测覆盖），手动补验
+- [ ] **切回 glm：确认分辨率档为 1K / 2K**——逻辑已测，手动补验
+- [ ] **切到 direct 模式：确认分辨率档为 1K / 2K / 4K**——逻辑已测，手动补验
+
+> 核心链路（文生图 + 图生图 + 元信息回流 + 档位渲染）已联调通过。剩余打勾项是 UI 细节补验，逻辑层均有单测覆盖；可在日常使用中顺带验证。
 
 ## 分阶段计划
 
-### 阶段 A：companion 侧 adapter + resolutionOptions 回流
+### 阶段 A：companion 侧 adapter + resolutionOptions 回流 ✅ 已完成
 
-- [ ] `providers/types.ts` 增加 `resolutionOptions` 字段
-- [ ] openai / glm adapter 声明各自的 resolutionOptions（等价现状）
-- [ ] 新增 `providers/doubao.ts`（generate + edit + sizeConstraints(step=1) + capability + resolutionOptions=[2k,3k,4k]）
-- [ ] `normalizeDoubaoSize` 纯函数 + 单测
-- [ ] registry 注册 doubao
-- [ ] `routes/auth.ts` + `types.ts` 回流 resolutionOptions
-- [ ] main.ts `PROVIDER_PRESETS` 加豆包预设
-- [ ] doubao.test.ts + openai/glm auth 回流补 resolutionOptions 断言
-- [ ] tsc + build 干净
+- [x] `providers/types.ts` 增加 `ResolutionOption` 类型 + `resolutionOptions` 字段
+- [x] openai / glm adapter 声明各自的 resolutionOptions（OpenAI [1k,2k,4k] / GLM [1k,2k]）
+- [x] 新增 `providers/doubao.ts`（generate + edit + sizeConstraints(step=1) + capability + resolutionOptions=[2k,3k,4k]）
+- [x] `normalizeDoubaoSize` 纯函数 + 单测
+- [x] registry 注册 doubao
+- [x] `routes/auth.ts` + `types.ts` 回流 resolutionOptions
+- [x] main.ts `PROVIDER_PRESETS` 加豆包预设
+- [x] doubao.test.ts(25) + openai/glm auth 回流补 resolutionOptions 断言
+- [x] tsc + build 干净（companion 全量 98 测试通过）
 
-### 阶段 B：web 侧档位渲染（D1）+ 自定义 minPixels 校验（D1b）
+### 阶段 B：web 侧档位渲染（D1）+ 自定义 minPixels 校验（D1b）✅ 已完成
 
-- [ ] 审查「带参考图编辑」与「mask 区域编辑」是否独立开关（D4 UI 前提）
-- [ ] `types/companion.ts` 增加 resolutionOptions
-- [ ] `settingsStore` 删除写死档位 + availableResolutionValues，改读 companion 回流（离线回退 OpenAI 默认）
-- [ ] applyProviderInfo 写入 resolutionOptions + 选中档回退
-- [ ] 补 settingsStore.test.ts / imagesApi.test.ts 用例（含 OpenAI/GLM 可见档位零变化的验收红线）
-- [ ] web 全量测试通过、vue-tsc 干净
+- [x] 审查「带参考图编辑」与「mask 区域编辑」是否独立开关 → **结论：独立**（generate vs edit 由 `referencedImageIds.length` 决定，mask 可选，`editModeEnabled` 只管 mask 流程）。豆包 `edit=true, mask=false` 直接可用，无需解耦。
+- [x] `types/companion.ts` 增加 resolutionOptions + `SizeResolution` 放开为 string（让 3k 能进）
+- [x] `settingsStore` 删除写死档位 + `availableResolutionValues`，改读 companion 回流（离线回退 OpenAI 默认）
+- [x] applyProviderInfo 写入 resolutionOptions + 选中档回退（离线/切换 provider 都处理）
+- [x] 补 settingsStore.test.ts / imagesApi.test.ts 用例（豆包档位 [2k,3k,4k]、minPixels 校验、离线回退）
+- [x] web 全量 216 测试通过、vue-tsc 干净
 
-### 阶段 C：联调（待用户侧）
+### 阶段 C：联调 ✅ 已完成（真实火山方舟 Key）
 
-- [ ] 真实火山方舟 Key 跑通手动联调清单
-- [ ] 验证 edit 端点真实字段名（`image` 单数/数组、有无 `strength`），必要时走 `editExtra` 透传
+- [x] 文生图跑通：`doubao-seedream-5-0-260128` + b64_json 返回正常，无水印
+- [x] 图生图跑通：edit 走 `/generations` + JSON `image` 字段（联调修正，原 `/images/edits` 返回 404）
+- [x] 参数栏回流验证：模型标签、档位 [2k,3k,4k]、区域编辑隐藏、背景/格式过滤
+- [x] 切换 provider 档位恢复验证
+- [x] 确认豆包**不返回 `revised_prompt`**（`data[0]` 只有 b64_json + size）
+
+**联调过程的关键修正**（已固化到代码 + 文档）：
+1. **model 名**：文档示例的 `doubao-seedream-3-0-t2i-250415` / `doubao-seedream-5-0-lite` 都无效，真实名 `doubao-seedream-5-0-260128`（火山方舟用模型名，非 endpoint id）。
+2. **edit 端点**：文档描述的 multipart `/images/edits` 不存在（404），实际共用 `/images/generations` + JSON `image` 字段。adapter 已改，废弃的 multipart 构造器已删。
 
 ## 成本估算
 
@@ -475,15 +496,15 @@ routes/images.ts（无改动，已统一走 resolveAdapter()）
 
 1. **D1 重构改变了 OpenAI/GLM 的实现路径**：把分辨率档从「web 写死 + maxPixels 过滤」改成「provider 声明」，OpenAI/GLM 的实现路径变了（不再走 `availableResolutionValues` 过滤），但它们声明的档位就是各自真实能力，和用户原本看到的吻合是自然结果而非刻意凑值。测试重点：各 provider 声明的档位正确、direct/离线回退默认档位正确、删除 `availableResolutionValues` 后无残留引用。
 
-2. **edit 端点真实形状待联调确认**：火山方舟 edits 端点的字段名（`image` 单数 vs `image[]`、是否有 `strength` 参数）文档描述与 OpenAI 接近，但真实 4xx 错误是最终判据。adapter 预留 `editExtra` 透传兜底；若出入大，edit 后置，不影响 generate（核心价值）。
+2. **~~edit 端点真实形状待联调确认~~**（联调已解决）：火山方舟**没有独立的 `/images/edits` 端点**（404），图生图共用 `/images/generations` + JSON `image` 字段（base64 data URL）。adapter 已按此实现并跑通。文档原描述（multipart edits）与真实行为不符，已修正。
 
-3. **3K 档的 targetPixels 取值**：3K 是豆包原生档，web 此前没有对应预设。文档取 `2880×1620 = 4,665,600`（16:9 下的 3K 标准），需确认这个 targetPixels 配合 `dimensionsForRatio` 算出的各比例尺寸都落在豆包 [3.6M, 16M] 区间内。极端比例（如 1:16 竖条）可能算出低于 minPixels 的尺寸——这种情况下 `getCustomSizeError` 会拦，但用户体验是「选了 3K + 极端比例却报错」，需联调确认是否要限制极端比例组合。
+3. **3K 档的 targetPixels 取值**：3K 是豆包原生档，web 此前没有对应预设。文档取 `2880×1620 = 4,665,600`（16:9 下的 3K 标准）。联调已验证文生图正常生成；极端比例（如 1:16 竖条）可能算出低于 minPixels 的尺寸，`getCustomSizeError` 会拦。
 
-4. **水印策略**：固定 `watermark=false`。若火山方舟政策变化强制带水印，adapter 需调整——但这是 provider 侧政策，不属于本轮范围。
+4. **水印策略**：固定 `watermark=false`。联调已验证无水印。若火山方舟政策变化强制带水印，adapter 需调整——但这是 provider 侧政策，不属于本轮范围。
 
-5. **模型 ID 漂移**：豆包 model ID 带日期版本号（`250415`），频繁更新。`login` 时用户可填自定义，降低漂移影响；adapter 不写死 model。
+5. **模型 ID 漂移**：豆包 model ID 带日期版本号（`260128`），会随版本更新。`login` 时用户可填自定义，降低漂移影响；adapter 不写死 model。
 
-6. **b64_json 体积**：豆包 4K 图的 b64 可能很大（几 MB）。Companion 的 body limit（阶段四安全加固设的）需确认能容纳豆包最大尺寸的 b64 响应，否则会被自己的限制截断。阶段 A 联调时验证。
+6. **~~b64_json 体积~~**（联调已验证）：豆包 4K 图的 b64 正常通过，未触发 companion body limit。
 
 ## 参考依据
 

--- a/docs/companion-providers-plan.md
+++ b/docs/companion-providers-plan.md
@@ -670,7 +670,7 @@ companion/src/providers/
 
 每个一个 `providers/<name>.ts`，注册到 registry，`login` 增加选项。按形状接近度排序：
 
-- **豆包（火山方舟）**：形状与 GLM 最接近（都是 OpenAI 兼容 `/images/generations`，返回 URL/b64），adapter 基本是 GLM 的复制 + 改 sizeConstraints + 改 base url。预估 2-3 人天。**独立设计方案见 [`companion-doubao-plan.md`](companion-doubao-plan.md)**——调研后发现豆包的 size 约束（总像素下限 minPixels）和原生图生图能力让它必须有独立 adapter，不能简单复制 GLM。
+- **豆包（火山方舟）✅ 已完成**：形状与 GLM 最接近（OpenAI 兼容 `/images/generations`，返回 b64），但调研后发现 size 约束（总像素下限 minPixels）和原生图生图能力让它必须有独立 adapter，不能复制 GLM。**独立设计方案见 [`companion-doubao-plan.md`](companion-doubao-plan.md)**。已实现 generate + edit（图生图共用 `/generations` + image 字段，联调确认）+ 分辨率档统一为 provider 声明。预估 2-3 人天。
 - **Qwen-Image（阿里千问团队）**：走 dashscope，形状待确认，可能需要异步轮询。预估 2-4 人天。
 - **通义万相 Wan（阿里万相实验室）**：dashscope，支持图像编辑（Wan 2.6），异步任务模式（提交拿 task_id → 轮询）。taskPoller 基础设施已在阶段一就位，adapter 内部 `await runAsyncTask({...})` 即可。预估 2-3 人天。
 

--- a/docs/companion-providers-plan.md
+++ b/docs/companion-providers-plan.md
@@ -122,7 +122,7 @@ GLM 的图片编辑能力分散在两个模型、两套接口上，且都不是 
 | 全图编辑（无 mask） | multipart `image[]` + prompt | GLM-4V chat + `image_url` + 指令 | 能，但要把 edits 整体重写成 chat messages，并从 chat 返回里提取图片 URL |
 | mask 局部重绘 | `image[]` + `mask` + `prompt` | 不支持 | 不能 |
 
-结论：mask 局部重绘是确认的功能缺口（非待实测），Web 端带 mask 的编辑请求 companion 只能报错。全图编辑理论可做，但翻译成本高（chat vs images 两种形状 + 返回解析），且效果是自然语言驱动，质量不如 mask 精确。阶段三据此调整（见「分阶段计划」）。
+结论：mask 局部重绘是确认的功能缺口（非待实测），Web 端带 mask 的编辑请求 companion 只能报错。全图编辑理论可做，但翻译成本高（chat vs images 两种形状 + 返回解析），且效果是自然语言驱动，质量不如 mask 精确——经评估投入产出比低，本轮确认不做（见「分阶段计划 → 阶段三」）。
 
 ## 目标
 
@@ -498,7 +498,7 @@ export const glmAdapter: ProviderAdapter = {
   id: "glm",
   capability: {
     generate: true,
-    edit: false,      // GLM-Image 无 edits 端点；GLM-4V 全图编辑走 chat 接口，阶段三视优先级决定
+    edit: false,      // 确认不做：GLM-Image 无 edits 端点；GLM-4V 全图编辑走 chat 接口，翻译成本高且效果依赖自然语言理解，投入产出比低
     mask: false,      // 智谱全系列不支持 mask 局部重绘（确认的缺口）
     backgrounds: ["auto", "opaque"],           // 不含 transparent（GLM 不支持透明）
     outputFormats: ["png", "jpeg"],            // 不含 webp
@@ -516,7 +516,7 @@ export const glmAdapter: ProviderAdapter = {
 
 UI 层按这份 capability 驱动：区域编辑 tag 因 `mask:false` 隐藏，背景选项因不含 transparent 而不显示「透明」，格式选项因不含 webp 而不显示「WebP」。OpenAI adapter 对应声明全能力（`mask:true`、backgrounds/format 都全），direct 模式下 UI 行为与现在完全一致。
 
-若阶段三决定做全图编辑，把 `edit` 打开即可（走 GLM-4V chat 翻译），`mask` 始终保持 `false`。Web 侧无感（Web 本来就在发编辑请求，companion 按 capability 决定报错还是翻译）。
+`capability.edit` 保持 `false`：GLM 全图编辑经评估确认不做（见「分阶段计划 → 阶段三」），Web 侧带图编辑请求始终报「不支持图片编辑」，无感切换。
 
 ## CLI 命令
 
@@ -594,7 +594,7 @@ companion/src/providers/
 - [ ] 参数栏「背景」选项不含「透明」（GLM 不支持 transparent）
 - [ ] 参数栏「格式」选项不含「WebP」（GLM 不支持 webp）
 - [ ] Web 端带 mask 的编辑图：确认报「不支持遮罩局部编辑」（GLM 确认不支持 mask），错误信息清晰
-- [ ] Web 端全图编辑（无 mask）：若阶段三已实现，确认经 GLM-4V chat 翻译跑通；若未实现，确认报「不支持图片编辑」
+- [ ] Web 端全图编辑（无 mask）：确认报「不支持图片编辑」（GLM 全图编辑经评估确认不做，`capability.edit=false`，route 层返回 501）
 - [ ] 切回 `login` 选 openai：确认参数栏模型回到 gpt-image-2，size 约束回到 step=16，区域编辑/背景/格式 tag 全部恢复，现有 OpenAI 中转站流程零回归
 
 ## 分阶段计划
@@ -655,21 +655,16 @@ companion/src/providers/
 
 **验收**：companion 侧 70 测试通过、tsc + build 干净。用户配置 GLM 凭据后，参数栏自动隐藏 GLM 不支持的选项（区域编辑/透明背景/webp），文生图与 OpenAI 体验一致。编辑图此时报「不支持」（因为 `capability.edit=false`，route 层返回 501）。真实联调由用户用智谱 API Key 完成。
 
-### 阶段三：GLM 全图编辑 adapter（可选，视优先级）
+### 阶段三：GLM 全图编辑 adapter —— ❌ 确认不做
 
 基于调研结论（见「图片编辑」），GLM 编辑能力有明确边界：
 
 - **mask 局部重绘**：确认不支持，不做。`capability.mask` 保持 `false`，带 mask 的编辑请求直接报错。
-- **全图编辑**：GLM-4V-Plus 能做，但走 `chat/completions` 接口，翻译成本高（edits 整体重写成 chat messages + 从 chat 返回提取图片 URL），且效果是自然语言驱动。
+- **全图编辑**：GLM-4V-Plus 能做，但走 `chat/completions` 接口，翻译成本高（edits 整体重写成 chat messages + 从 chat 返回提取图片 URL），且效果是自然语言驱动、质量不稳定。经评估投入产出比低，**确认不做**。
 
-- [ ] 若决定做全图编辑：
-  - GLM adapter 增加 `edit`：OpenAI edits（multipart image[] + prompt）→ GLM-4V chat（image_url + 指令）
-  - 解析 chat 返回提取图片 URL → urlToB64 → OpenAI 形状
-  - `capability: { edit: true, mask: false }`
-  - 单元测试 + 手动联调（重点验证自然语言指令的编辑质量是否可接受）
-- [ ] 若决定不做：保持 `capability.edit=false`，带图编辑请求报错，本阶段跳过
+`capability: { edit: false, mask: false }` 保持不变，Web 侧带图编辑请求始终报「不支持图片编辑」。
 
-**验收**：mask 局部重绘确认不支持（报错）。全图编辑视优先级决定是否实现；不做也不阻塞本轮 MVP，因为文生图（阶段二）是核心价值。
+**验收**：mask 局部重绘和全图编辑均确认不支持（报错），不影响文生图（阶段二，核心价值）。本轮 MVP 以 GLM 文生图为终点。
 
 ### 阶段四（后续，本轮不做）：更多 provider
 
@@ -681,7 +676,7 @@ companion/src/providers/
 
 ## 风险与开放问题
 
-1. **GLM 编辑能力有明确缺口**：mask 局部重绘确认不支持（智谱全系列无 mask inpainting），带 mask 的编辑请求只能报错。全图编辑可经 GLM-4V chat 接口实现，但形状差异大、效果依赖自然语言理解，质量不稳定。这是本轮 MVP 的已知功能边界，文生图（核心价值）不受影响。
+1. **GLM 编辑能力有明确缺口**：mask 局部重绘确认不支持（智谱全系列无 mask inpainting），带 mask 的编辑请求只能报错；全图编辑经评估确认不做（翻译成本高、效果依赖自然语言理解，投入产出比低）。这是本轮 MVP 的已知功能边界，文生图（核心价值）不受影响。
 
 2. **参数保真 vs 用户体验**：报错策略下，用户设了 transparent 调 GLM 会直接报错。错误信息要足够清晰（指明哪个参数、为什么、怎么改），否则用户会困惑「为什么同样的设置在 OpenAI 能用在 GLM 不行」。
 
@@ -700,8 +695,8 @@ companion/src/providers/
 | 阶段一（companion 侧）✅ | adapter 骨架 + openai 抽取 + multipart 解析 + provider 元信息回流 + taskPoller 基础设施（零行为变化） | 2.5-3 人天 |
 | 阶段一（web 侧消费）✅ | `CompanionAuthStatus` 类型 + settingsStore 常量→ref + capability 驱动 UI + ApiSettingsPanel 回写 + validateBackground 改 capability | 1-1.5 人天 |
 | 阶段二 ✅ | GLM 文生图 adapter + login/status 改造 + urlToB64 + 测试（联调待用户侧） | 3-4 人天 |
-| 阶段三 | GLM 全图编辑 adapter（可选，经 GLM-4V chat 翻译） | 2-3 人天（不做则 0） |
-| **合计（本轮 MVP）** | **GLM generate 打通，edit 视情况** | **7-10 人天** |
+| 阶段三 ❌ | GLM 全图编辑 adapter（确认不做：翻译成本高、效果不稳定，投入产出比低） | 0 |
+| **合计（本轮 MVP）** | **GLM generate 打通，edit 不做** | **7-9 人天** |
 
 后续每增加一个 provider，成本约 2-3 人天（写 adapter + 测试 + 联调）。通义万相虽是异步轮询型，但 taskPoller 基础设施已在阶段一就位，不再额外增加成本。
 

--- a/docs/companion-providers-plan.md
+++ b/docs/companion-providers-plan.md
@@ -670,7 +670,7 @@ companion/src/providers/
 
 每个一个 `providers/<name>.ts`，注册到 registry，`login` 增加选项。按形状接近度排序：
 
-- **豆包（火山方舟）**：形状与 GLM 最接近（都是 OpenAI 兼容 `/images/generations`，返回 URL/b64），adapter 基本是 GLM 的复制 + 改 sizeConstraints + 改 base url。预估 2-3 人天。
+- **豆包（火山方舟）**：形状与 GLM 最接近（都是 OpenAI 兼容 `/images/generations`，返回 URL/b64），adapter 基本是 GLM 的复制 + 改 sizeConstraints + 改 base url。预估 2-3 人天。**独立设计方案见 [`companion-doubao-plan.md`](companion-doubao-plan.md)**——调研后发现豆包的 size 约束（总像素下限 minPixels）和原生图生图能力让它必须有独立 adapter，不能简单复制 GLM。
 - **Qwen-Image（阿里千问团队）**：走 dashscope，形状待确认，可能需要异步轮询。预估 2-4 人天。
 - **通义万相 Wan（阿里万相实验室）**：dashscope，支持图像编辑（Wan 2.6），异步任务模式（提交拿 task_id → 轮询）。taskPoller 基础设施已在阶段一就位，adapter 内部 `await runAsyncTask({...})` 即可。预估 2-3 人天。
 

--- a/src/features/companion/useCompanionConnection.test.ts
+++ b/src/features/companion/useCompanionConnection.test.ts
@@ -58,6 +58,11 @@ function makeStatus(
       maxAspectRatio: 3,
       defaultSize: "1024x1024",
     },
+    resolutionOptions: [
+      { value: "1k", label: "1K", targetPixels: 1024 * 1024 },
+      { value: "2k", label: "2K", targetPixels: 2048 * 2048 },
+      { value: "4k", label: "4K", targetPixels: 3840 * 2160 },
+    ],
     ...overrides,
   };
 }

--- a/src/services/imagesApi.test.ts
+++ b/src/services/imagesApi.test.ts
@@ -482,6 +482,27 @@ describe("getCustomSizeError", () => {
     expect(getCustomSizeError(1280, 1280, GLM_CONSTRAINTS)).toBe("");
     expect(getCustomSizeError(1024, 576, GLM_CONSTRAINTS)).toBe("");
   });
+
+  it("Doubao enforces minPixels floor (3686400), no step constraint", () => {
+    // 豆包 step=1 → 无步长对齐，任意整数像素都接受（单边范围由 min/max 兜底）
+    const DOUBAO_CONSTRAINTS: SizeConstraints = {
+      step: 1,
+      min: 512,
+      max: 4096,
+      maxPixels: 16777216,
+      minPixels: 3686400,
+      maxAspectRatio: 16,
+      defaultSize: "2048x2048",
+    };
+    // 1024x1024 = 1048576 < minPixels 3686400 → 报总像素下限错
+    expect(getCustomSizeError(1024, 1024, DOUBAO_CONSTRAINTS)).toContain("总像素");
+    // 1920x1920 = 3686400 刚好等于下限 → 合法
+    expect(getCustomSizeError(1920, 1920, DOUBAO_CONSTRAINTS)).toBe("");
+    // 2048x2048 = 4194304 在范围内 → 合法
+    expect(getCustomSizeError(2048, 2048, DOUBAO_CONSTRAINTS)).toBe("");
+    // step=1：2345x2345 这种非步长倍数也合法（只要像素在范围）
+    expect(getCustomSizeError(2345, 2345, DOUBAO_CONSTRAINTS)).toBe("");
+  });
 });
 
 function jsonResponse(payload: unknown, status = 200) {

--- a/src/services/urlSettings.ts
+++ b/src/services/urlSettings.ts
@@ -337,8 +337,10 @@ function normalizeSize(value: unknown): GenerationParams["size"] | undefined {
 }
 
 function normalizeResolution(value: unknown): SizeResolution | undefined {
-  return typeof value === "string" && RESOLUTION_VALUES.includes(value as SizeResolution)
-    ? value as SizeResolution
+  // URL 参数只认 web 原生的 1k/2k/4k（兜底）；companion 回流的 3k 等不通过 URL 传入。
+  return typeof value === "string" &&
+    (RESOLUTION_VALUES as readonly string[]).includes(value)
+    ? value
     : undefined;
 }
 

--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -42,6 +42,11 @@ function makeStatus(overrides: Partial<CompanionAuthStatus> = {}): CompanionAuth
       maxAspectRatio: 3,
       defaultSize: "1024x1024",
     },
+    resolutionOptions: [
+      { value: "1k", label: "1K", targetPixels: 1024 * 1024 },
+      { value: "2k", label: "2K", targetPixels: 2048 * 2048 },
+      { value: "4k", label: "4K", targetPixels: 3840 * 2160 },
+    ],
     ...overrides,
   };
 }
@@ -160,7 +165,7 @@ describe("settingsStore capability-driven UI", () => {
     expect(s.sizeResolutionOptions.map((o) => o.value)).toEqual(["1k", "2k", "4k"]);
   });
 
-  it("applies GLM size constraints: hides 4K, custom 512-2048 step 32", () => {
+  it("applies GLM size constraints: resolutionOptions [1k,2k] (GLM declares its own tiers)", () => {
     const s = useSettingsStore();
     s.applyProviderInfo(
       makeStatus({
@@ -173,10 +178,15 @@ describe("settingsStore capability-driven UI", () => {
           maxAspectRatio: null,
           defaultSize: "1280x1280",
         },
+        // D1：GLM 声明自己的档位 [1k, 2k]——4K 不显示是因为没声明，不再靠 maxPixels 过滤
+        resolutionOptions: [
+          { value: "1k", label: "1K", targetPixels: 1024 * 1024 },
+          { value: "2k", label: "2K", targetPixels: 2048 * 2048 },
+        ],
       }),
     );
 
-    // GLM maxPixels=4194304，4K(8294400) 被隐藏，只剩 1K/2K
+    // GLM 声明的档位 [1k, 2k]
     expect(s.sizeResolutionOptions.map((o) => o.value)).toEqual(["1k", "2k"]);
     expect(s.sizeStep).toBe(32);
     expect(s.minCustomDimension).toBe(512);
@@ -184,13 +194,13 @@ describe("settingsStore capability-driven UI", () => {
     expect(s.currentSizeConstraints.maxAspectRatio).toBeNull();
   });
 
-  it("falls back resolution when provider drops it (GLM hides 4K, current 4K resets)", () => {
+  it("falls back resolution when provider drops it (GLM [1k,2k], current 4K resets)", () => {
     const s = useSettingsStore();
     // OpenAI 模式下选 4K
     s.applySizeResolution("4k");
     expect(s.sizeResolution).toBe("4k");
 
-    // 切 GLM → 4K 不可用，自动回退
+    // 切 GLM → 4K 不在 GLM 声明的档位里，自动回退到第一个可用档
     s.applyProviderInfo(
       makeStatus({
         sizeConstraints: {
@@ -202,6 +212,10 @@ describe("settingsStore capability-driven UI", () => {
           maxAspectRatio: null,
           defaultSize: "1280x1280",
         },
+        resolutionOptions: [
+          { value: "1k", label: "1K", targetPixels: 1024 * 1024 },
+          { value: "2k", label: "2K", targetPixels: 2048 * 2048 },
+        ],
       }),
     );
     expect(s.sizeResolution).toBe("1k");
@@ -254,6 +268,61 @@ describe("settingsStore capability-driven UI", () => {
     s.imageWidth = 2048;
     s.imageHeight = 512;
     expect(s.customSizeError).toBe("");
+  });
+
+  it("Doubao declares [2k, 3k, 4k] tiers (no 1k, native 3k appears)", () => {
+    const s = useSettingsStore();
+    s.applyProviderInfo(
+      makeStatus({
+        provider: "doubao",
+        sizeConstraints: {
+          step: 1,
+          min: 512,
+          max: 4096,
+          maxPixels: 16777216,
+          minPixels: 3686400,
+          maxAspectRatio: 16,
+          defaultSize: "2048x2048",
+        },
+        resolutionOptions: [
+          { value: "2k", label: "2K", targetPixels: 2048 * 2048 },
+          { value: "3k", label: "3K", targetPixels: 2880 * 1620 },
+          { value: "4k", label: "4K", targetPixels: 4096 * 2160 },
+        ],
+      }),
+    );
+    // 豆包档位 [2k, 3k, 4k]——1K 被自然排除，3K 是豆包原生档
+    expect(s.sizeResolutionOptions.map((o) => o.value)).toEqual(["2k", "3k", "4k"]);
+    // 默认选中档 1k 不在豆包列表里 → 回退第一个 2k
+    expect(s.sizeResolution).toBe("2k");
+    // step=1（无步长约束）
+    expect(s.sizeStep).toBe(1);
+    // 豆包 minPixels=3686400，自定义尺寸低于下限报错
+    s.applySizePreset("custom");
+    s.imageWidth = 1024;
+    s.imageHeight = 1024;
+    expect(s.customSizeError).toContain("总像素");
+  });
+
+  it("applyProviderInfo(null) resets resolutionOptions to OpenAI defaults [1k,2k,4k]", () => {
+    const s = useSettingsStore();
+    // 先切豆包（档位 [2k,3k,4k]，选中 3k）
+    s.applyProviderInfo(
+      makeStatus({
+        resolutionOptions: [
+          { value: "2k", label: "2K", targetPixels: 2048 * 2048 },
+          { value: "3k", label: "3K", targetPixels: 2880 * 1620 },
+          { value: "4k", label: "4K", targetPixels: 4096 * 2160 },
+        ],
+      }),
+    );
+    s.applySizeResolution("3k");
+    expect(s.sizeResolution).toBe("3k");
+
+    // 离线 → 回退 OpenAI 默认档位 [1k,2k,4k]，3k 不在默认列表 → 回退 1k
+    s.applyProviderInfo(null);
+    expect(s.sizeResolutionOptions.map((o) => o.value)).toEqual(["1k", "2k", "4k"]);
+    expect(s.sizeResolution).toBe("1k");
   });
 });
 

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -69,11 +69,16 @@ const SIZE_RESOLUTION_OPTIONS = [
   { value: "4k", label: "4K", targetPixels: 3840 * 2160 },
 ] as const;
 
-/** 返回 maxPixels 约束下可用的分辨率档 value 列表（升序）。供 applyProviderInfo 校正用。 */
-function availableResolutionValues(maxPixels: number): SizeResolution[] {
-  return SIZE_RESOLUTION_OPTIONS.filter((opt) => opt.targetPixels <= maxPixels)
-    .map((opt) => opt.value);
-}
+/**
+ * direct 模式 / companion 离线时的兜底默认档位（OpenAI 形状 1K/2K/4K）。
+ * 走 companion 的 provider 一律用 companion 回流的 resolutionOptions，不读这个。
+ */
+const DEFAULT_RESOLUTION_OPTIONS: ReadonlyArray<{
+  value: string;
+  label: string;
+  targetPixels: number;
+}> = SIZE_RESOLUTION_OPTIONS;
+
 // OpenAI/gpt-image-2 的默认尺寸约束。companion 在线时被 providerCapability/sizeConstraints
 // 覆盖；离线或未回流时回退到这些值，保持现状行为。
 const DEFAULT_SIZE_STEP = 16;
@@ -136,12 +141,13 @@ export const useSettingsStore = defineStore("settings", () => {
   const activeSizePreset = ref<GenerationParams["size"]>("auto");
   const sizeResolution = ref<SizeResolution>("1k");
   const sizeRatioOptions = SIZE_RATIO_OPTIONS;
-  // 分辨率档按 provider maxPixels 过滤：某档 targetPixels 超过 maxPixels 则不显示。
-  // GLM maxPixels=4194304 → 4K(8294400) 被隐藏；OpenAI maxPixels=8294400 → 4K 保留。
+  // 分辨率档位：companion 声明、web 渲染（D1）。
+  // 走 companion 的 provider 一律用 companion 回流的档位（如豆包 [2k,3k,4k]）；
+  // direct / 离线 / 未回流时用 OpenAI 兜底默认 [1k,2k,4k]。
+  // 不再用 maxPixels 运行时过滤——provider 声明什么是它自己的真实能力。
+  const resolutionOptions = ref(DEFAULT_RESOLUTION_OPTIONS.map((o) => ({ ...o })));
   const sizeResolutionOptions = computed(() =>
-    SIZE_RESOLUTION_OPTIONS.filter(
-      (opt) => opt.targetPixels <= maxCustomPixels.value,
-    ).map(({ value, label }) => ({ value, label })),
+    resolutionOptions.value.map(({ value, label }) => ({ value, label })),
   );
   const quality = ref<GenerationParams["quality"]>("auto");
   const background = ref<GenerationParams["background"]>("auto");
@@ -234,14 +240,15 @@ export const useSettingsStore = defineStore("settings", () => {
       outputFormat.value,
   );
 
-  // 尺寸计算（读 sizeConstraints ref，受 companion 回流驱动）
+  // 尺寸计算（读 sizeConstraints ref + resolutionOptions ref，受 companion 回流驱动）
   function dimensionsForRatio(ratio: SizeRatio, resolution: SizeResolution) {
     const ratioOption =
       SIZE_RATIO_OPTIONS.find((option) => option.value === ratio) ??
       SIZE_RATIO_OPTIONS[4];
+    // 读 companion 回流的 resolutionOptions（如豆包 [2k,3k,4k]），找不到时回退第一个。
     const resolutionOption =
-      SIZE_RESOLUTION_OPTIONS.find((option) => option.value === resolution) ??
-      SIZE_RESOLUTION_OPTIONS[0];
+      resolutionOptions.value.find((option) => option.value === resolution) ??
+      resolutionOptions.value[0];
     const aspect = ratioOption.widthRatio / ratioOption.heightRatio;
     let width = Math.sqrt(resolutionOption.targetPixels * aspect);
     let height = width / aspect;
@@ -326,6 +333,14 @@ export const useSettingsStore = defineStore("settings", () => {
       maxCustomPixels.value = DEFAULT_MAX_CUSTOM_PIXELS;
       minCustomPixels.value = DEFAULT_MIN_CUSTOM_PIXELS;
       maxAspectRatio.value = DEFAULT_MAX_ASPECT_RATIO;
+      resolutionOptions.value = DEFAULT_RESOLUTION_OPTIONS.map((o) => ({ ...o }));
+      // 离线时若当前选中档不在默认列表（如刚从豆包切回 direct，还停在 3k），回退第一个。
+      const defaultValues = DEFAULT_RESOLUTION_OPTIONS.map((o) => o.value);
+      if (!defaultValues.includes(sizeResolution.value)) {
+        sizeResolution.value = defaultValues[0] ?? "1k";
+        const ratio = normalizeSizePreset(activeSizePreset.value);
+        if (isSizeRatio(ratio)) applyRatioDimensions(ratio, sizeResolution.value);
+      }
       // 离线时 model 不回退——保留用户上次生效的 model，避免 UI 闪烁
       return;
     }
@@ -342,6 +357,8 @@ export const useSettingsStore = defineStore("settings", () => {
     maxCustomPixels.value = sc.maxPixels;
     minCustomPixels.value = sc.minPixels;
     maxAspectRatio.value = sc.maxAspectRatio;
+    // 写入 companion 声明的分辨率档位（companion 声明、web 渲染）。
+    resolutionOptions.value = status.resolutionOptions.map((o) => ({ ...o }));
     if (status.model) model.value = status.model;
     // 当前选中的背景/格式若已不在新 provider 支持列表，立即回退到第一个可用值。
     // 放在这里（同步）而非 watch，避免 UI 短暂停留在失效值上。
@@ -351,10 +368,11 @@ export const useSettingsStore = defineStore("settings", () => {
     if (!status.capability.outputFormats.includes(outputFormat.value)) {
       outputFormat.value = status.capability.outputFormats[0] ?? "png";
     }
-    // 当前分辨率档若超过新 provider 的 maxPixels（如 GLM 下 4K 不可达），回退到第一个可用档。
-    const availableRes = availableResolutionValues(sc.maxPixels);
-    if (!availableRes.includes(sizeResolution.value)) {
-      sizeResolution.value = availableRes[0] ?? "1k";
+    // 当前分辨率档若不在新 provider 声明的档位列表，回退到第一个可用档。
+    // （如从豆包 [2k,3k,4k] 切到 GLM [1k,2k]，停在 4k 的要回退；从 GLM 切到豆包，停在 1k 的要回退）
+    const availableValues = status.resolutionOptions.map((o) => o.value);
+    if (!availableValues.includes(sizeResolution.value)) {
+      sizeResolution.value = availableValues[0] ?? "1k";
       // 尺寸变了，若当前是比例模式需重算尺寸
       const ratio = normalizeSizePreset(activeSizePreset.value);
       if (isSizeRatio(ratio)) applyRatioDimensions(ratio, sizeResolution.value);

--- a/src/types/companion.ts
+++ b/src/types/companion.ts
@@ -23,6 +23,16 @@ export type CompanionSizeConstraints = {
   defaultSize: string;
 };
 
+/**
+ * 分辨率档位（companion 声明、web 渲染）。
+ * value 用 string 而非枚举，以便接收 web 此前没有的档位（如豆包的 "3k"）。
+ */
+export type CompanionResolutionOption = {
+  value: string;
+  label: string;
+  targetPixels: number;
+};
+
 export type CompanionAuthStatus = {
   provider: string;
   mode: "api_key";
@@ -34,6 +44,11 @@ export type CompanionAuthStatus = {
   capability: CompanionProviderCapability;
   /** provider 的尺寸软约束，web 据此生成合法尺寸选项。 */
   sizeConstraints: CompanionSizeConstraints;
+  /**
+   * provider 支持的分辨率档位（companion 声明、web 渲染）。
+   * web 不再写死 1K/2K/4K、不再用 maxPixels 运行时过滤，直接渲染本字段。
+   */
+  resolutionOptions: CompanionResolutionOption[];
 };
 
 export type CompanionAuthStatusResult =

--- a/src/types/studio.ts
+++ b/src/types/studio.ts
@@ -67,7 +67,11 @@ export type ImageAsset = {
 };
 
 export type SizeRatio = "21:9" | "16:9" | "3:2" | "4:3" | "1:1" | "3:4" | "2:3" | "9:16";
-export type SizeResolution = "1k" | "2k" | "4k";
+/**
+ * 分辨率档位。放开为 string 而非枚举，以便接收 companion 回流的任意档位
+ * （如豆包的 "3k"，web 此前没有）。持久化/URL 里仍是 "1k"/"2k"/"4k" 这些值。
+ */
+export type SizeResolution = string;
 
 export type GenerationParams = {
   size: "auto" | SizeRatio | "custom";


### PR DESCRIPTION
## Summary

Adds the **Doubao (Volcengine Ark Seedream)** image provider as the third provider alongside OpenAI and GLM, and lands the supporting multi-provider architecture. Ships as companion **v0.5.0** (published to npm).

## What's included

### 🆕 Doubao Seedream provider
- New independent adapter `providers/doubao.ts` (generate + edit) — cannot reuse GLM due to fundamentally different size constraints, native image-to-image, and Doubao-specific fields.
- **generate**: requests `response_format=b64_json` directly (skips URL→b64), `watermark=false` (no "AI generated" watermark).
- **edit** (image-to-image): integration-tested — Doubao has **no separate `/images/edits` endpoint** (404); image-to-image shares `/images/generations` with a JSON `image` field (base64 data URL).
- Size constraints: `step=1` (no stride alignment), pixel floor `minPixels≈3.6M`, aspect ratio `[1/16, 16]`, native **3K** tier.
- Real model id `doubao-seedream-5-0-260128` (uses model name, not endpoint id); returns no `revised_prompt`.

### 🏗️ Architecture: provider-declared resolution tiers (D1)
- Resolution tiers move from **web-hardcoded + maxPixels filter** → **companion-declared, web-rendered**.
- Drops the `availableResolutionValues` runtime filter (the GLM 4K special-case) entirely.
- Each provider declares its real tiers: OpenAI `[1k,2k,4k]`, GLM `[1k,2k]`, Doubao `[2k,3k,4k]`.
- `SizeResolution` widened to `string` so Doubao's native 3K can render; direct/offline falls back to OpenAI defaults.

### 🔧 Multi-provider foundation (earlier commits in this branch)
- GLM-Image provider + provider-driven size constraints + capability-driven UI (phase 1 translation layer).
- GLM full-image edit adapter explicitly **not pursuing** (documented decision).

### 📦 Release
- Companion bumped to **0.5.0** (both `package.json` and the `VERSION` const in `main.ts` — fixes a previous miss where `main.ts` stayed at 0.3.0 when 0.4.0 shipped).

## Test results
- companion: 98 tests pass, tsc/build clean
- web: 216 tests pass, vue-tsc/build clean
- Integration tested with a real Volcengine Ark API key (generate + image-to-image + metadata backflow all verified)

## Docs
- New `docs/companion-doubao-plan.md` (design + integration findings).
- Updated `docs/companion-providers-plan.md` (phase 4 Doubao marked complete).