### PR TITLE
release: companion v1.1.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# GPT Image Studio — 仓库根环境变量模板
+# 复制为 .env 后填值（.env 已 gitignore，不进仓库）。
+# 目前只有 docker-compose 的 companion-server 服务读取本文件。
+
+# ─── 共享密钥 ───
+# 与宿主后端共享的 HS256 JWT 密钥（Companion 验签用）。≥32 字符随机串。
+JWT_SECRET=please-change-companion-jwt-secret
+# 平台级管理密钥（Companion /admin/** 接口鉴权用）。
+ADMIN_API_KEY=please-change-companion-admin-key
+
+# ─── CORS 白名单（server 模式，被 qiankun 嵌入的宿主 origin）───
+# 空格或逗号分隔任意多个完整 origin，想放行几个加几个。
+# companion 侧切分为 --allow-origin 列表；CLI 显式传 --allow-origin 可覆盖。
+# 改完重建容器生效：
+#   docker compose --profile companion-server up -d --force-recreate companion-server
+COMPANION_ALLOW_ORIGINS=http://127.0.0.1:5599 http://localhost:5680 http://127.0.0.1:5680

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ desktop/src-tauri/WixTools/
 
 # qiankun 宿主示例的本地配置（含 JWT，用 config.example.json 复制生成）
 examples/qiankun-host/config.json
+
+# docker-compose 本地密钥（JWT_SECRET / ADMIN_API_KEY），切勿提交
+.env

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GPT Image Studio
 
-[![Version](https://img.shields.io/badge/version-1.0.0-brightgreen)](https://github.com/honlnk/gpt-image-studio/releases)
+[![Version](https://img.shields.io/badge/version-1.1.0-brightgreen)](https://github.com/honlnk/gpt-image-studio/releases)
 [![npm](https://img.shields.io/npm/v/@honlnk/image-studio-companion?label=companion%20npm)](https://www.npmjs.com/package/@honlnk/image-studio-companion)
 [![Deploy](https://github.com/honlnk/gpt-image-studio/actions/workflows/deploy.yml/badge.svg)](https://github.com/honlnk/gpt-image-studio/actions/workflows/deploy.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honlnk/image-studio-companion",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Local CLI companion for GPT Image Studio image API credential proxying.",
   "type": "module",
   "bin": {

--- a/companion/src/cli.ts
+++ b/companion/src/cli.ts
@@ -80,13 +80,31 @@ type ServeLikeOptions = {
   managed?: boolean;
 };
 
+/**
+ * 从环境变量解析 --allow-origin 默认值：空格/逗号分隔多个完整 origin。
+ * CLI 显式传 --allow-origin 时优先（commander 行为：显式值覆盖默认值）。
+ * 无环境变量时返回 undefined（等价于"无默认值"），调用方按 [] 兜底。
+ */
+function parseAllowOriginsEnv(value: string | undefined): string[] | undefined {
+  if (!value) return undefined;
+  const list = value
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return list.length ? list : undefined;
+}
+
 function addServeOptions(command: ReturnType<typeof program.command>) {
   return command
     .option("-p, --port <port>", "监听端口", DEFAULT_PORT)
     .option("-H, --host <host>", "监听地址（local 模式忽略，恒为 127.0.0.1）", process.env.COMPANION_HOST)
     .option("--deployment-mode <mode>", "部署形态：local 或 server", process.env.COMPANION_DEPLOYMENT_MODE)
     .option("--channel <channel>", "安全渠道：stable 或 dev", process.env.GPT_IMAGE_STUDIO_COMPANION_CHANNEL)
-    .option("--allow-origin <origin...>", "额外允许的完整 origin，例如 http://localhost:5173")
+    .option(
+      "--allow-origin <origin...>",
+      "额外允许的完整 origin，例如 http://localhost:5173（也可用 COMPANION_ALLOW_ORIGINS，空格/逗号分隔多个）",
+      parseAllowOriginsEnv(process.env.COMPANION_ALLOW_ORIGINS),
+    )
     .addOption(new Option("--managed", "由 start 命令托管的后台服务").hideHelp());
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,11 +57,12 @@ services:
   # 需要环境变量：JWT_SECRET（与宿主共享）、ADMIN_API_KEY（平台级管理密钥）。
   companion-server:
     profiles: ["companion-server"]
-    image: ghcr.io/honlnk/gpt-image-studio-companion:latest
-    # 如需从源码构建，取消下行注释：
-    # build:
-    #   context: .
-    #   target: companion
+    # 本地从源码构建（含 COMPANION_ALLOW_ORIGINS 列表白名单支持）。
+    # 想切回官方预构建镜像：注释掉 build 段，image 改回 ghcr.io/honlnk/gpt-image-studio-companion:latest。
+    build:
+      context: .
+      target: companion
+    image: gpt-image-studio-companion:local
     container_name: gpt-image-studio-companion-server
     ports:
       - "19751:19751"
@@ -77,8 +78,21 @@ services:
       # 逃生门（仅本地调试）：server 模式 OSS 用 oss-credentials.json 长期 AK。
       # 违背 D11（生产应走宿主 STS 签发），无宿主后端的本地演示才开启。
       - COMPANION_OSS_LONG_TERM_AK=1
+      # CORS 白名单：单个列表变量，空格/逗号分隔任意多个宿主 origin（companion 侧切分）。
+      # 在仓库根 .env 里配 COMPANION_ALLOW_ORIGINS，想加几个加几个，重建容器生效。
+      - COMPANION_ALLOW_ORIGINS=${COMPANION_ALLOW_ORIGINS:-}
     restart: unless-stopped
-    command: ["node", "companion/dist/main.js", "serve", "--host", "0.0.0.0", "--port", "19751", "--deployment-mode", "server", "--allow-origin", "http://127.0.0.1:5599"]
+    # --allow-origin 不再硬编码：由 COMPANION_ALLOW_ORIGINS 提供默认（cli.ts 读取并按空格/逗号切分）。
+    command:
+      - node
+      - companion/dist/main.js
+      - serve
+      - --host
+      - "0.0.0.0"
+      - --port
+      - "19751"
+      - --deployment-mode
+      - server
 
 volumes:
   companion-data:

--- a/examples/README.md
+++ b/examples/README.md
@@ -76,6 +76,10 @@ cp ~/.gpt-image-studio/oss-credentials.json ~/.gpt-image-studio/credentials.json
 docker compose --profile companion-server up -d companion-server
 ```
 
+- CORS 白名单（被嵌入的宿主 origin）也走仓库根 `.env` 的 `COMPANION_ALLOW_ORIGINS`：
+  空格/逗号分隔任意多个 origin（如 `http://127.0.0.1:5599 http://localhost:5680`），
+  想放行几个加几个，改完 `--force-recreate` 重建容器生效。companion 侧会把它切分成
+  `--allow-origin` 列表（CLI 显式传参仍可覆盖）。
 - 数据目录映射：`~/.gpt-image-studio-docker` → 容器 `/data`
 - compose 里开了 `COMPANION_OSS_LONG_TERM_AK=1` 逃生门：server 模式的 OSS 存储
   允许用 `oss-credentials.json` 里的长期 AK（**仅本地调试**，违背 D11——生产环境

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,42 +22,48 @@ pnpm dev
 
 对应 `src/main.ts` 的 qiankun 生命周期导出与嵌入态逻辑（契约测试见 `src/qiankun-embed.test.ts`，部署细节见 `docs/deployment-guide.md`）。
 
-宿主是单个 `index.html`（qiankun 2.x UMD 已 vendor 到 `vendor/qiankun-2.10.5.umd.js`，本地加载不走 CDN），带一个**一键登录页**：点登录按钮后自动完成「浏览器内自签 JWT → 检查/激活 OSS 数据集 → 挂载子应用」，JWT 缓存 localStorage（30 天），未过期则跳过登录页直接进主界面。不再需要手动跑 `sign-jwt.mjs` 拼 config.json。
+宿主是 `index.html` + 轻量宿主服务 `serve.mjs`（qiankun 2.x UMD 已 vendor 到 `vendor/qiankun-2.10.5.umd.js`，本地加载不走 CDN）。带一个**一键登录页**：点登录按钮后，宿主服务在服务端签发 JWT（`/api/login`）→ 检查/激活 OSS 数据集 → 挂载子应用，JWT 缓存 localStorage（30 天），未过期则跳过登录页直接进主界面。配置全部走 `.env`，不再手工编辑 config.json。
 
-> 安全说明：生产语义里 JWT 应由宿主后端签发，本 demo 宿主是纯静态页、没有后端，
-> 故把签发搬进浏览器（WebCrypto HMAC-SHA256），secret 只存在于 gitignore 的
-> `config.json`，与此前手填 JWT 的安全水位一致。**这套自签逻辑仅限本地 demo**。
+> 安全说明：与正式部署一致——JWT 由宿主服务 `serve.mjs` 在服务端用 `JWT_SECRET` 签发，
+> ADMIN_API_KEY 由 `serve.mjs` 代理 `/admin/**` 时注入，**浏览器全程不持有任何 secret**。
+> 共享密钥存于仓库根 `gpt-image-studio/.env`（与 companion 容器共享），demo 专属配置存于
+> `examples/qiankun-host/.env`。
 
 性能说明：`qiankun.start({ sandbox: false })`——demo 只有一个子应用、无隔离需求，关掉沙箱可避免 LegacySandbox 对子应用所有 `window` 全局读写的 Proxy 损耗（嵌入态明显慢于独立态 8888 的最大单一因素）。真实宿主若需隔离，可用提速沙箱 `{ speedy: true }`（qiankun 2.x 实验特性）。
 
 ### 启动步骤（共 4 个进程/端口）
 
 ```bash
+# 0. 准备 .env（一次性，已 gitignore 不进仓库）
+#    仓库根：共享密钥（与 companion 容器共享）
+cat > .env <<'EOF'
+JWT_SECRET=<32+字符随机串>
+ADMIN_API_KEY=<平台管理密钥>
+EOF
+#    demo 目录：demo 专属配置（可从 .env.example 复制后改）
+cp examples/qiankun-host/.env.example examples/qiankun-host/.env
+
 # 1. 子应用产物（entry，端口 4173）
 pnpm build && pnpm preview
 
-# 2. Companion server 模式（端口 19751，与宿主共享 JWT_SECRET，
-#    --allow-origin 必须允许宿主页面的 origin）
+# 2. Companion server 模式（端口 19751，读仓库根 .env，--allow-origin 放行宿主 origin）
+#    用 Docker（推荐，见下一节）或直跑：
 cd companion && pnpm build
-JWT_SECRET=<32+字符随机串> node dist/main.js serve \
-  --port 19751 --deployment-mode server \
+set -a; . ../.env; set +a   # source 仓库根 .env，避免命令行内联密钥
+node dist/main.js serve --port 19751 --deployment-mode server \
   --allow-origin http://127.0.0.1:5599
 
-# 3. 生成 config.json（config.json 已 gitignore，不进仓库）：
-#    填入与第 2 步相同的 JWT_SECRET，以及 OSS 的 endpoint/bucket
-cd examples/qiankun-host
-cp config.example.json config.json  # 然后编辑 jwtSecret / oss 字段
-
-# 4. 启动宿主静态服务（端口 5599，任意静态服务器均可）
-python3 -m http.server 5599
+# 3. 宿主服务（端口 5599，读两个 .env，托管页面 + 服务端签 JWT + 代理 /admin）
+cd examples/qiankun-host && node serve.mjs
 # 浏览器打开 http://127.0.0.1:5599 → 点「登录」即可
 ```
 
 宿主顶栏会显示子应用挂载状态（MOUNTED）；「重新挂载子应用」按钮实际是整页刷新。
 
-### 用 Docker 跑 Companion（可选，替代上面的第 2 步）
+### 用 Docker 跑 Companion（推荐，替代上面的第 2 步）
 
-项目根目录的 `docker-compose.yml` 提供了 `companion-server` 服务（server 模式专用）：
+项目根目录的 `docker-compose.yml` 提供了 `companion-server` 服务（server 模式专用），
+共享密钥直接读仓库根 `.env`（docker compose 自动加载），无需命令行内联：
 
 ```bash
 # 准备独立数据目录（与 local 模式的 ~/.gpt-image-studio 隔离），
@@ -66,9 +72,8 @@ mkdir -p ~/.gpt-image-studio-docker
 cp ~/.gpt-image-studio/oss-credentials.json ~/.gpt-image-studio/credentials.json \
   ~/.gpt-image-studio-docker/
 
-# 构建并启动（端口 19751）
-JWT_SECRET=<32+字符随机串> ADMIN_API_KEY=<平台管理密钥> \
-  docker compose --profile companion-server up -d --build companion-server
+# 启动（端口 19751，JWT_SECRET / ADMIN_API_KEY 由仓库根 .env 注入）
+docker compose --profile companion-server up -d companion-server
 ```
 
 - 数据目录映射：`~/.gpt-image-studio-docker` → 容器 `/data`
@@ -77,7 +82,7 @@ JWT_SECRET=<32+字符随机串> ADMIN_API_KEY=<平台管理密钥> \
   OSS 必须走宿主 STS 签发，见 `docs/deployment-guide.md` §5.4）。没有宿主后端的
   本地演示才需要它。多用户共享同一把 AK 时按 `users/<userId>/` 前缀隔离。
 - 各用户首次登录时没有激活数据集，宿主登录流程检测到 404 会自动调
-  `POST /storage/datasets/activate` 激活 `config.json` 里配置的 OSS 数据集，
+  `POST /storage/datasets/activate` 激活 `examples/qiankun-host/.env` 里配置的 OSS 数据集，
   无需手动 curl。
   注意：Companion 自带管理页（`/admin`）是本机单用户管理面，server 模式下
   已禁用（404）——多租户存储由宿主/API 按用户管理。
@@ -85,6 +90,6 @@ JWT_SECRET=<32+字符随机串> ADMIN_API_KEY=<平台管理密钥> \
 ### 注意
 
 - **必须用 `http://127.0.0.1:5599` 打开宿主页，不能用 `localhost:5599`**——二者在浏览器看来是两个不同 origin，Companion 的 CORS 白名单（`--allow-origin http://127.0.0.1:5599`）只放行前者。用 localhost 打开会导致所有 Companion 请求报 `Failed to fetch`（CORS 拦截），表现为子应用"离线"、toast"读取本地数据失败"、宿主列表"加载失败"。
-- JWT 由登录流程在浏览器内自签，有效期 30 天并缓存 localStorage；过期后回到登录页再点一次即可。「退出登录」按钮清除缓存并刷新。`sign-jwt.mjs` 仍保留，供绕过页面手动签 token 调试用（如 curl Companion API）。
+- JWT 由宿主服务 `serve.mjs` 服务端签发（`/api/login`），有效期 30 天并缓存 localStorage；过期后回到登录页再点一次即可。「退出登录」按钮清除缓存并刷新。`sign-jwt.mjs` 仍保留，供绕过页面手动签 token 调试用（如 `JWT_SECRET=xxx node sign-jwt.mjs` 给 curl 用）。
 - 改完 `src/main.ts` 的嵌入逻辑后必须重新 `pnpm build`，preview 才会 serve 新产物。
 - 嵌入态 CSS 由子应用 `main.ts` 的 `injectEmbeddedCss` 通过 `__INJECTED_PUBLIC_PATH_BY_QIANKUN__` 注入宿主 document.head，不依赖 qiankun 的样式处理。

--- a/examples/qiankun-host/.env.example
+++ b/examples/qiankun-host/.env.example
@@ -1,6 +1,7 @@
 # qiankun demo 宿主配置示例——复制为 .env 后按需修改。
-# 共享密钥（JWT_SECRET / ADMIN_API_KEY）请填在仓库根 gpt-image-studio/.env，
-# 由 serve.mjs 一并读取，这里只放 demo 专属配置。
+# 共享密钥（JWT_SECRET / ADMIN_API_KEY）与 companion CORS 白名单（COMPANION_ALLOW_ORIGINS）
+# 请填在仓库根 gpt-image-studio/.env（见根目录 .env.example），由 serve.mjs / 容器分别读取，
+# 这里只放 demo 专属配置。
 
 COMPANION_URL=http://127.0.0.1:19751
 SUBAPP_URL=http://127.0.0.1:4173

--- a/examples/qiankun-host/.env.example
+++ b/examples/qiankun-host/.env.example
@@ -1,0 +1,13 @@
+# qiankun demo 宿主配置示例——复制为 .env 后按需修改。
+# 共享密钥（JWT_SECRET / ADMIN_API_KEY）请填在仓库根 gpt-image-studio/.env，
+# 由 serve.mjs 一并读取，这里只放 demo 专属配置。
+
+COMPANION_URL=http://127.0.0.1:19751
+SUBAPP_URL=http://127.0.0.1:4173
+HOST_PORT=5599
+DEMO_USER_SUB=qiankun-preview-user
+DEMO_USER_NAME=qiankun 预览用户
+JWT_TTL_SECONDS=2592000
+OSS_ENDPOINT=oss-cn-beijing.aliyuncs.com
+OSS_BUCKET=gpt-image-blob
+HIDE_SIDEBAR=true

--- a/examples/qiankun-host/config.example.json
+++ b/examples/qiankun-host/config.example.json
@@ -1,8 +1,0 @@
-{
-  "companionUrl": "http://127.0.0.1:19751",
-  "jwtSecret": "REPLACE_WITH_JWT_SECRET",
-  "adminApiKey": "REPLACE_WITH_ADMIN_API_KEY",
-  "user": { "sub": "qiankun-preview-user", "displayName": "qiankun 预览用户" },
-  "oss": { "endpoint": "oss-cn-beijing.aliyuncs.com", "bucket": "gpt-image-blob" },
-  "hideSidebar": true
-}

--- a/examples/qiankun-host/index.html
+++ b/examples/qiankun-host/index.html
@@ -316,51 +316,29 @@
 
 <script>
 // ─── 嵌入配置（注入给子应用的 props） ───
-// config.json（gitignore，本地私有）格式见 config.example.json。
-// jwt 不再手写进配置——登录流程在浏览器内用 jwtSecret 自签（WebCrypto HMAC-SHA256）。
-let HOST_CONFIG = { companionUrl: '', jwtSecret: '', adminApiKey: '', user: null, oss: null, jwt: '', hideSidebar: true };
+// 配置由宿主服务 serve.mjs 的 /api/config 下发（非敏感）；JWT 由 /api/login 服务端签发，
+// 浏览器不持有任何 secret（与正式部署一致）。
+let HOST_CONFIG = { companionUrl: '', subappUrl: '', user: null, oss: null, jwt: '', hideSidebar: true };
 
 async function loadConfig() {
   try {
-    const res = await fetch('./config.json');
+    const res = await fetch('/api/config');
     if (res.ok) return await res.json();
   } catch (e) {}
   return {
     companionUrl: 'http://127.0.0.1:19751',
-    jwtSecret: '',
-    adminApiKey: '',
+    subappUrl: 'http://127.0.0.1:4173',
     user: { sub: 'qiankun-preview-user', displayName: 'qiankun 预览用户' },
     oss: null,
     hideSidebar: true,
   };
 }
 
-// ─── 浏览器内 JWT 自签（HS256，仅本地 demo） ───
-// 生产语义里 JWT 应由宿主后端签发；本 demo 宿主是纯静态页、没有后端，
-// 故把签发搬进浏览器。secret 与此前一样只存在于 gitignore 的 config.json，
-// 安全水位不变。
-function b64urlBytes(bytes) {
-  let bin = '';
-  for (const b of bytes) bin += String.fromCharCode(b);
-  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
-function b64urlText(s) {
-  return b64urlBytes(new TextEncoder().encode(s));
-}
-async function signJwt(secret, payload) {
-  const header = b64urlText(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
-  const body = b64urlText(JSON.stringify(payload));
-  const key = await crypto.subtle.importKey(
-    'raw', new TextEncoder().encode(secret),
-    { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'],
-  );
-  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(`${header}.${body}`));
-  return `${header}.${body}.${b64urlBytes(new Uint8Array(sig))}`;
-}
+// ─── JWT 签发已移至宿主服务 serve.mjs（/api/login，服务端 HS256）───
+// 浏览器不再持有 jwtSecret；登录流程直接向 /api/login 取已签好的 JWT。
 
 // ─── JWT 本地缓存：未过期则跳过登录页直接进主界面 ───
 const JWT_CACHE_KEY = 'qiankun-demo-jwt';
-const JWT_TTL_SECONDS = 30 * 24 * 3600; // 30 天
 
 function readCachedJwt() {
   try {
@@ -373,17 +351,13 @@ function readCachedJwt() {
   } catch (e) { return null; }
 }
 
-// ─── 登录流程：签 JWT → 确保数据集激活 → 返回 JWT ───
+// ─── 登录流程：向宿主服务取 JWT → 确保数据集激活 → 返回 JWT ───
 async function performLogin(msgEl) {
-  if (!HOST_CONFIG.jwtSecret) throw new Error('config.json 缺少 jwtSecret');
+  // JWT 由宿主服务 serve.mjs 在服务端签发（/api/login），浏览器不持有 secret。
   msgEl.textContent = '正在签发登录凭证...';
-  const now = Math.floor(Date.now() / 1000);
-  const jwt = await signJwt(HOST_CONFIG.jwtSecret, {
-    sub: HOST_CONFIG.user.sub,
-    display_name: HOST_CONFIG.user.displayName,
-    iat: now,
-    exp: now + JWT_TTL_SECONDS,
-  });
+  const loginRes = await fetch('/api/login', { method: 'POST' });
+  if (!loginRes.ok) throw new Error(`签发 JWT 失败：HTTP ${loginRes.status} ${await loginRes.text()}`);
+  const { jwt } = await loginRes.json();
 
   // 确保该用户有激活数据集：清库/首次登录后是 404，自动激活 OSS 数据集，
   // 不再手动 curl POST /storage/datasets/activate。
@@ -391,7 +365,7 @@ async function performLogin(msgEl) {
   const headers = { Authorization: `Bearer ${jwt}` };
   const activeRes = await fetch(`${HOST_CONFIG.companionUrl}/storage/datasets/active`, { headers });
   if (activeRes.status === 404) {
-    if (!HOST_CONFIG.oss) throw new Error('config.json 缺少 oss 配置，无法自动初始化数据集');
+    if (!HOST_CONFIG.oss) throw new Error('配置缺少 oss，无法自动初始化数据集');
     msgEl.textContent = '正在初始化 OSS 数据集...';
     const actRes = await fetch(`${HOST_CONFIG.companionUrl}/storage/datasets/activate`, {
       method: 'POST',
@@ -529,8 +503,8 @@ window.addEventListener('popstate', () => {
 });
 
 // ═══ 管理页（#/admin hash 路由） ═══
-// server 模式适配版：端点走 ADMIN_API_KEY（凭据）/ JWT（数据集）/ 公开（health）。
-// 不依赖被禁用的 /admin/api/*（commit 657c172，__local__ 视图多租户下误导）。
+// server 模式适配版：凭据走宿主代理 /api/admin/**（serve.mjs 持有 ADMIN_API_KEY）、
+// 数据集走 JWT、health 公开。不依赖被禁用的 /admin/api/*（commit 657c172，__local__ 视图多租户下误导）。
 
 function openAdminPage() { location.hash = '#/admin'; }
 function closeAdminPage() {
@@ -557,12 +531,11 @@ const adminState = {
   activeDataset: null,
 };
 
-// 带 ADMIN_API_KEY 的 fetch（凭据管理）
+// 凭据管理走宿主服务代理 /api/admin/**（serve.mjs 注入 ADMIN_API_KEY，浏览器不持有密钥）
 async function adminFetch(path, options = {}) {
   const headers = { ...(options.headers || {}) };
-  headers['Authorization'] = `Bearer ${HOST_CONFIG.adminApiKey}`;
   if (options.body && !headers['Content-Type']) headers['Content-Type'] = 'application/json';
-  const res = await fetch(`${HOST_CONFIG.companionUrl}${path}`, { ...options, headers });
+  const res = await fetch(`/api${path}`, { ...options, headers });
   if (!res.ok) {
     let msg = `HTTP ${res.status}`;
     try { const j = await res.json(); if (j.error) msg = j.error; } catch {}
@@ -843,7 +816,7 @@ function boot(jwt) {
   qiankun.registerMicroApps([
     {
       name: 'gpt-image-studio',
-      entry: '//127.0.0.1:4173',
+      entry: HOST_CONFIG.subappUrl,
       container: '#image-studio-container',
       activeRule: location.pathname,
       props: {

--- a/examples/qiankun-host/serve.mjs
+++ b/examples/qiankun-host/serve.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+/**
+ * qiankun demo 宿主服务（取代 python3 -m http.server）。
+ *
+ * 设计目标：让 demo 的密钥管理与「正式部署」一致——
+ *   - 共享密钥（JWT_SECRET / ADMIN_API_KEY）只存在 .env，服务端持有，绝不下发浏览器；
+ *   - JWT 由本服务在服务端签发（/api/login），浏览器不再自签、不持有 jwtSecret；
+ *   - 平台管理接口（/admin/**）由本服务代理（/api/admin/**），浏览器不持有 ADMIN_API_KEY；
+ *   - 配置全部 .env 驱动，不再手工编辑 config.json、不再命令行内联密钥。
+ *
+ * 读取两个 .env：
+ *   - 仓库根 gpt-image-studio/.env        → JWT_SECRET、ADMIN_API_KEY（与 companion 容器共享）
+ *   - 本目录 examples/qiankun-host/.env    → demo 专属配置（地址/端口/用户/OSS 等）
+ *
+ * 路由：
+ *   GET  /api/config        → 非敏感配置（companionUrl/subappUrl/user/oss/hideSidebar）
+ *   POST /api/login         → 服务端签发 JWT，返回 { jwt, exp }
+ *   ALL  /api/admin/*       → 代理 companion /admin/*，注入 ADMIN_API_KEY
+ *   GET  /                  → index.html（其余静态资源按路径返回）
+ *
+ * 用法：node serve.mjs
+ */
+import { createServer } from "node:http";
+import { createHmac } from "node:crypto";
+import { readFile, stat } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { extname, join, normalize, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT_ENV = join(SCRIPT_DIR, "../../.env");
+const DEMO_ENV = join(SCRIPT_DIR, ".env");
+
+// ─── 极简 .env 解析（无依赖）───
+function parseEnv(text) {
+  const out = {};
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq < 0) continue;
+    const key = line.slice(0, eq).trim();
+    let val = line.slice(eq + 1).trim();
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    out[key] = val;
+  }
+  return out;
+}
+
+async function loadEnv(file) {
+  try {
+    return parseEnv(await readFile(file, "utf8"));
+  } catch (e) {
+    console.error(`无法读取 ${file}：${e.message}`);
+    return {};
+  }
+}
+
+const [rootEnv, demoEnv] = await Promise.all([loadEnv(ROOT_ENV), loadEnv(DEMO_ENV)]);
+
+// 共享密钥（来自仓库根 .env）
+const JWT_SECRET = rootEnv.JWT_SECRET;
+const ADMIN_API_KEY = rootEnv.ADMIN_API_KEY;
+// demo 配置（来自本目录 .env）
+const COMPANION_URL = (demoEnv.COMPANION_URL || "http://127.0.0.1:19751").replace(/\/$/, "");
+const SUBAPP_URL = demoEnv.SUBAPP_URL || "http://127.0.0.1:4173";
+const HOST_PORT = Number(demoEnv.HOST_PORT || 5599);
+const DEMO_USER_SUB = demoEnv.DEMO_USER_SUB || "qiankun-preview-user";
+const DEMO_USER_NAME = demoEnv.DEMO_USER_NAME || "qiankun 预览用户";
+const JWT_TTL_SECONDS = Number(demoEnv.JWT_TTL_SECONDS || 2592000);
+const OSS_ENDPOINT = demoEnv.OSS_ENDPOINT || "";
+const OSS_BUCKET = demoEnv.OSS_BUCKET || "";
+const HIDE_SIDEBAR = String(demoEnv.HIDE_SIDEBAR ?? "true") === "true";
+
+if (!JWT_SECRET) {
+  console.error("✗ 仓库根 gpt-image-studio/.env 缺少 JWT_SECRET（与 companion 容器共享）。");
+  process.exit(1);
+}
+if (!ADMIN_API_KEY) {
+  console.error("✗ 仓库根 gpt-image-studio/.env 缺少 ADMIN_API_KEY（平台管理密钥）。");
+  process.exit(1);
+}
+
+// ─── HS256 JWT 签发（服务端，与 companion 验签共用 JWT_SECRET）───
+function b64url(buf) {
+  return Buffer.from(buf)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+function signJwt(payload) {
+  const header = b64url(Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })));
+  const body = b64url(Buffer.from(JSON.stringify(payload)));
+  const sig = createHmac("sha256", JWT_SECRET).update(`${header}.${body}`).digest();
+  return `${header}.${body}.${b64url(sig)}`;
+}
+
+// ─── 非敏感配置（下发给浏览器）───
+function publicConfig() {
+  return {
+    companionUrl: COMPANION_URL,
+    subappUrl: SUBAPP_URL,
+    user: { sub: DEMO_USER_SUB, displayName: DEMO_USER_NAME },
+    oss: OSS_ENDPOINT && OSS_BUCKET ? { endpoint: OSS_ENDPOINT, bucket: OSS_BUCKET } : null,
+    hideSidebar: HIDE_SIDEBAR,
+  };
+}
+
+function sendJson(res, status, obj) {
+  const body = Buffer.from(JSON.stringify(obj));
+  res.writeHead(status, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Content-Length": body.length,
+  });
+  res.end(body);
+}
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const c of req) chunks.push(c);
+  return Buffer.concat(chunks);
+}
+
+// ─── 静态文件托管（本目录）───
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".mjs": "application/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".ico": "image/x-icon",
+  ".map": "application/json",
+};
+
+async function serveStatic(req, res, urlPath) {
+  // 防穿越：归一化后必须仍在 SCRIPT_DIR 内
+  const rel = decodeURIComponent(urlPath).replace(/^\/+/, "");
+  const target = normalize(join(SCRIPT_DIR, rel));
+  if (!target.startsWith(SCRIPT_DIR)) {
+    sendJson(res, 403, { error: "forbidden" });
+    return;
+  }
+  let s;
+  try {
+    s = await stat(target);
+  } catch {
+    sendJson(res, 404, { error: "not found", path: urlPath });
+    return;
+  }
+  // 目录：回落 index.html
+  const file = s.isDirectory() ? join(target, "index.html") : target;
+  try {
+    await stat(file);
+  } catch {
+    sendJson(res, 404, { error: "not found", path: urlPath });
+    return;
+  }
+  res.writeHead(200, {
+    "Content-Type": MIME[extname(file).toLowerCase()] || "application/octet-stream",
+    "Cache-Control": "no-cache",
+  });
+  createReadStream(file).pipe(res);
+}
+
+// ─── /api/admin/** 代理到 companion /admin/**，注入 ADMIN_API_KEY ───
+// 透传 method/query/body/content-type；剔除上游 CORS 头（同源代理，浏览器侧 CORS 由本服务负责）。
+const STRIPPED_UPSTREAM_HEADERS = new Set([
+  "content-length", "connection", "transfer-encoding", "content-encoding", "keep-alive",
+  "access-control-allow-origin", "access-control-allow-credentials", "access-control-allow-methods",
+  "access-control-allow-headers", "access-control-max-age", "access-control-expose-headers",
+]);
+
+async function proxyAdmin(req, res, rest, search) {
+  const target = `${COMPANION_URL}/admin/${rest}${search || ""}`;
+  const headers = { Authorization: `Bearer ${ADMIN_API_KEY}` };
+  if (req.headers["content-type"]) headers["Content-Type"] = req.headers["content-type"];
+  let body;
+  if (req.method !== "GET" && req.method !== "HEAD") body = await readBody(req);
+  let upstream;
+  try {
+    upstream = await fetch(target, { method: req.method, headers, body });
+  } catch (e) {
+    sendJson(res, 502, { error: "companion unreachable", detail: e.message });
+    return;
+  }
+  const buf = Buffer.from(await upstream.arrayBuffer());
+  const respHeaders = { "Content-Type": upstream.headers.get("content-type") || "application/json" };
+  // 复制安全响应头
+  for (const [k, v] of upstream.headers) {
+    if (STRIPPED_UPSTREAM_HEADERS.has(k.toLowerCase())) continue;
+    respHeaders[k] = v;
+  }
+  res.writeHead(upstream.status, respHeaders);
+  res.end(buf);
+}
+
+// ─── 主路由 ───
+const server = createServer(async (req, res) => {
+  const { pathname, search } = new URL(req.url, "http://localhost");
+
+  // API 路由
+  if (pathname === "/api/config" && req.method === "GET") {
+    sendJson(res, 200, publicConfig());
+    return;
+  }
+  if (pathname === "/api/login" && req.method === "POST") {
+    const now = Math.floor(Date.now() / 1000);
+    const jwt = signJwt({
+      sub: DEMO_USER_SUB,
+      display_name: DEMO_USER_NAME,
+      iat: now,
+      exp: now + JWT_TTL_SECONDS,
+    });
+    sendJson(res, 200, { jwt, exp: now + JWT_TTL_SECONDS });
+    return;
+  }
+  if (pathname.startsWith("/api/admin/")) {
+    const rest = pathname.slice("/api/admin/".length);
+    await proxyAdmin(req, res, rest, search || "");
+    return;
+  }
+  if (pathname.startsWith("/api/")) {
+    sendJson(res, 404, { error: "unknown api", path: pathname });
+    return;
+  }
+
+  // 静态资源
+  await serveStatic(req, res, pathname);
+});
+
+server.listen(HOST_PORT, () => {
+  console.log("┌──────────────────────────────────────────────────────");
+  console.log("│ qiankun demo 宿主服务已启动");
+  console.log(`│   页面:  http://127.0.0.1:${HOST_PORT}`);
+  console.log(`│   子应用: ${SUBAPP_URL}（需另起 pnpm preview）`);
+  console.log(`│   companion: ${COMPANION_URL}`);
+  console.log("│ 密钥来自 .env（服务端持有），浏览器不持有 secret");
+  console.log("└──────────────────────────────────────────────────────");
+});


### PR DESCRIPTION
## 内容

- feat(companion): 支持 `COMPANION_ALLOW_ORIGINS` 列表环境变量(df3420b)
  - `--allow-origin` 新增环境变量默认值(空格/逗号分隔),CLI 显式传参仍可覆盖
  - docker-compose 改为 environment 注入,移除内联 flag
  - 新增根 `.env.example` 模板
- refactor(examples): qiankun demo 改为 .env 驱动 + serve.mjs 宿主服务(dfee17a)
- chore(companion): bump version to 1.1.0

## 发布后

合并后打 tag `companion-v1.1.0` 推送即可触发 release CI(npm + 双 registry Docker 镜像)。