### PR TITLE
feat(studio): 预渲染首屏入场动画打磨

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -124,24 +124,35 @@ function render(props: QiankunProps = {}) {
   }
 
   const mountTarget = props.container ?? '#app'
-  // 预渲染内容处理策略：
-  // 1. 检测到预渲染标记时，先用 CSS 隐藏 body（避免白屏闪烁）
-  // 2. 用普通 createApp 挂载（不用 createSSRApp 的 hydration，因为
-  //    IndexedDB 是异步的，首次渲染时数据还没恢复，hydration 必然 mismatch，
-  //    Vue 会清空 DOM 并重建，导致白屏）
-  // 3. 挂载完成后淡入显示
-  if (prerendered) {
-    document.documentElement.style.setProperty('opacity', '0')
-    document.documentElement.style.setProperty('transition', 'opacity 0.2s ease-in')
+  // 预渲染首屏的入场动画：挂载前把 #app 置于「透明 + 轻微下沉 + 微模糊」，
+  // 挂载重建 DOM 后上浮淡入，掩盖重建瞬间。作用在 #app 而非 documentElement——
+  // 页面背景不动，只有内容入场。
+  // 动画结束必须清理内联样式：transform/filter 会为 position:fixed 后代
+  // （移动端侧边栏）创建新的包含块。prefers-reduced-motion 用户跳过动画。
+  const appEl = prerendered ? document.querySelector<HTMLElement>('#app') : null
+  const animateEntrance =
+    appEl !== null &&
+    !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  if (animateEntrance && appEl) {
+    appEl.style.cssText = 'opacity:0;transform:translateY(10px);filter:blur(4px)'
   }
   app.mount(mountTarget, false)
-  if (prerendered) {
-    // 挂载完成后淡入
+  if (animateEntrance && appEl) {
+    appEl.style.transition =
+      'opacity .5s cubic-bezier(.22,1,.36,1), transform .5s cubic-bezier(.22,1,.36,1), filter .5s cubic-bezier(.22,1,.36,1)'
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
-        document.documentElement.style.setProperty('opacity', '1')
+        appEl.style.opacity = '1'
+        appEl.style.transform = 'translateY(0)'
+        appEl.style.filter = 'blur(0)'
       })
     })
+    const cleanup = () => {
+      appEl.style.cssText = ''
+    }
+    appEl.addEventListener('transitionend', cleanup, { once: true })
+    // 兜底：后台标签页里 transitionend 可能不触发
+    setTimeout(cleanup, 900)
   }
 
   // 嵌入态：注册宿主消息监听（postMessage 通道，见 embeddedBridge.ts）。


### PR DESCRIPTION
## 概要

把白屏修复引入的 0.2s 生硬淡入升级为有高级感的入场动画：

- 缓动换 easeOutQuint（`cubic-bezier(.22,1,.36,1)`，先快后慢的丝滑减速）
- 透明度之外叠加 10px 轻微上浮与 4px 微模糊→清晰（对焦感）
- 时长拉长到 0.5s
- 作用域从 documentElement 收窄到 #app：页面背景不动，只有内容入场
- 动画结束清理内联样式（transform/filter 会为 position:fixed 后代创建包含块）；transitionend + setTimeout 双保险
- prefers-reduced-motion 用户跳过动画

## 验证

- [x] 本地 preview：动画中初始样式正确（opacity 0 + translateY(10px) + blur(4px) + transition），900ms 后内联样式完全清理
- [x] 挂载后界面完整渲染，Vue 正常接管
- [x] typecheck 通过