### PR TITLE
feat(studio): 启动画面（splash）替代空白加载期

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,9 +130,89 @@
       "logo": "https://image.honlnk.com/logo.svg"
     }
     </script>
+
+    <!-- 启动画面关键样式：必须 inline——要在外部 CSS/JS bundle 加载完成前就生效 -->
+    <style>
+      #app-splash {
+        position: fixed;
+        inset: 0;
+        z-index: 9999;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: radial-gradient(circle at 50% 38%, #1c2333 0%, #0f1420 75%);
+      }
+      #app-splash-inner {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 14px;
+      }
+      #app-splash svg {
+        animation: splash-breathe 1.8s ease-in-out infinite;
+      }
+      #app-splash .splash-title {
+        color: #f9fafb;
+        font-size: 18px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        font-family: ui-sans-serif, system-ui, sans-serif;
+      }
+      #app-splash .splash-tagline {
+        color: #9ca3af;
+        font-size: 13px;
+        font-family: ui-sans-serif, system-ui, sans-serif;
+      }
+      @keyframes splash-breathe {
+        0%,
+        100% {
+          transform: scale(1);
+          opacity: 1;
+        }
+        50% {
+          transform: scale(1.05);
+          opacity: 0.88;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        #app-splash svg {
+          animation: none;
+        }
+      }
+    </style>
   </head>
   <body>
     <div id="app"></div>
+    <!-- 启动画面：纯 HTML + inline CSS，页面解析即呈现（不依赖 JS bundle），
+         盖住预渲染的空工作台；JS 就绪后由 main.ts 淡出并移除。
+         Logo 内联自 public/favicon.svg（改图标需同步此处）。 -->
+    <div id="app-splash" role="status" aria-label="应用加载中">
+      <div id="app-splash-inner">
+        <svg xmlns="http://www.w3.org/2000/svg" width="72" height="72" viewBox="0 0 64 64" fill="none" role="img" aria-label="GPT Image Studio">
+          <defs>
+            <linearGradient id="mark-fill" x1="10" y1="8" x2="52" y2="56" gradientUnits="userSpaceOnUse">
+              <stop offset="0" stop-color="#22D3EE"/>
+              <stop offset="0.52" stop-color="#34D399"/>
+              <stop offset="1" stop-color="#F59E0B"/>
+            </linearGradient>
+            <linearGradient id="panel-fill" x1="16" y1="15" x2="48" y2="49" gradientUnits="userSpaceOnUse">
+              <stop offset="0" stop-color="#FFFFFF"/>
+              <stop offset="1" stop-color="#ECFEFF"/>
+            </linearGradient>
+          </defs>
+          <rect x="6" y="6" width="52" height="52" rx="14" fill="#111827"/>
+          <path d="M20 16H44C46.2091 16 48 17.7909 48 20V44C48 46.2091 46.2091 48 44 48H20C17.7909 48 16 46.2091 16 44V20C16 17.7909 17.7909 16 20 16Z" fill="url(#panel-fill)"/>
+          <path d="M19.5 39.5L26.25 32.75C27.3546 31.6454 29.1454 31.6454 30.25 32.75L34 36.5L36.75 33.75C37.8546 32.6454 39.6454 32.6454 40.75 33.75L46.5 39.5V44C46.5 45.3807 45.3807 46.5 44 46.5H20C18.6193 46.5 17.5 45.3807 17.5 44V41.5C18.245 41.0752 18.9142 40.408 19.5 39.5Z" fill="url(#mark-fill)"/>
+          <circle cx="39.5" cy="24.5" r="4.5" fill="#F97316"/>
+          <path d="M32 9L34.116 14.884L40 17L34.116 19.116L32 25L29.884 19.116L24 17L29.884 14.884L32 9Z" fill="#FFFFFF"/>
+          <path d="M32 11.75L33.221 15.779L37.25 17L33.221 18.221L32 22.25L30.779 18.221L26.75 17L30.779 15.779L32 11.75Z" fill="#111827"/>
+          <path d="M50 40L55 45L49 47L50 40Z" fill="#FFFFFF"/>
+          <path d="M50.641 42.406L52.734 44.499L50.222 45.337L50.641 42.406Z" fill="#111827"/>
+        </svg>
+        <div class="splash-title">GPT Image Studio</div>
+        <div class="splash-tagline">本地优先的 AI 图片创作工作台</div>
+      </div>
+    </div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -124,22 +124,26 @@ function render(props: QiankunProps = {}) {
   }
 
   const mountTarget = props.container ?? '#app'
-  // 预渲染首屏的入场动画：挂载前把 #app 置于「透明 + 轻微下沉 + 微模糊」，
-  // 挂载重建 DOM 后上浮淡入，掩盖重建瞬间。作用在 #app 而非 documentElement——
-  // 页面背景不动，只有内容入场。
-  // 动画结束必须清理内联样式：transform/filter 会为 position:fixed 后代
-  // （移动端侧边栏）创建新的包含块。prefers-reduced-motion 用户跳过动画。
+  // 启动画面（#app-splash）：index.html 内置的纯 HTML 覆盖层，页面解析即呈现
+  //（不依赖 JS bundle），盖住其下预渲染的空工作台。JS 就绪后 splash 淡出
+  //（内容轻微上浮），#app 同步上浮 + 去模糊入场——品牌画面到工作区只有一次
+  // 平滑交接，避免「工作台闪现 → 消失 → 再淡入」的断裂感。
+  // qiankun 嵌入态宿主不加载 index.html（无 splash 元素），行为同前。
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
   const appEl = prerendered ? document.querySelector<HTMLElement>('#app') : null
-  const animateEntrance =
-    appEl !== null &&
-    !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  const animateEntrance = appEl !== null && !reduceMotion
   if (animateEntrance && appEl) {
     appEl.style.cssText = 'opacity:0;transform:translateY(10px);filter:blur(4px)'
   }
   app.mount(mountTarget, false)
-  if (animateEntrance && appEl) {
+
+  // #app 入场：初始隐藏态 → 上浮淡入。动画结束必须清理内联样式——
+  // transform/filter 会为 position:fixed 后代（移动端侧边栏）创建新的包含块；
+  // transitionend + setTimeout 双保险（后台标签页 transitionend 可能不触发）。
+  const playAppEntrance = () => {
+    if (!animateEntrance || !appEl) return
     appEl.style.transition =
-      'opacity .5s cubic-bezier(.22,1,.36,1), transform .5s cubic-bezier(.22,1,.36,1), filter .5s cubic-bezier(.22,1,.36,1)'
+      'opacity .55s cubic-bezier(.22,1,.36,1), transform .55s cubic-bezier(.22,1,.36,1), filter .55s cubic-bezier(.22,1,.36,1)'
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         appEl.style.opacity = '1'
@@ -151,8 +155,32 @@ function render(props: QiankunProps = {}) {
       appEl.style.cssText = ''
     }
     appEl.addEventListener('transitionend', cleanup, { once: true })
-    // 兜底：后台标签页里 transitionend 可能不触发
-    setTimeout(cleanup, 900)
+    setTimeout(cleanup, 1000)
+  }
+
+  const splash = document.getElementById('app-splash')
+  if (!splash) {
+    playAppEntrance()
+  } else {
+    // splash 最短展示时长，避免秒开时一闪而过；performance.now() ≈ 自页面开始
+    // 加载至今（即 splash 已展示的时长）。dev 下刷新频繁，不设下限。
+    const SPLASH_MIN_MS = import.meta.env.DEV ? 0 : 700
+    const dismissDelay = Math.max(0, SPLASH_MIN_MS - performance.now())
+    setTimeout(() => {
+      playAppEntrance()
+      if (reduceMotion) {
+        splash.remove()
+        return
+      }
+      const inner = splash.firstElementChild as HTMLElement | null
+      splash.style.transition = 'opacity .45s cubic-bezier(.22,1,.36,1)'
+      splash.style.opacity = '0'
+      if (inner) {
+        inner.style.transition = 'transform .45s cubic-bezier(.22,1,.36,1)'
+        inner.style.transform = 'translateY(-10px)'
+      }
+      setTimeout(() => splash.remove(), 500)
+    }, dismissDelay)
   }
 
   // 嵌入态：注册宿主消息监听（postMessage 通道，见 embeddedBridge.ts）。


### PR DESCRIPTION
## 概要

首开体验从「工作台闪现 → 消失 → 再淡入」升级为品牌启动画面：

- **index.html 内置 splash**：深色径向渐变底（聚光感）+ 内联 Logo（零请求）+ 名称/标语 + Logo 呼吸动画。纯 HTML + inline CSS，页面解析即显示，盖住预渲染的空工作台
- **main.ts 联动交接**：JS 就绪后 splash 淡出（内容上浮）与 #app 上浮入场同时进行；splash 最短展示 700ms（performance.now() 计已展示时长，慢网络下自然覆盖 bundle 下载期），dev 不设下限
- 动画结束 splash 从 DOM 移除；prefers-reduced-motion 跳过全部动画
- qiankun 嵌入态无 splash（宿主不加载 index.html），行为不变；桌面端自动获得

## 验证

- [x] 时序实测：150ms splash 可见 + #app 隐藏 → 800ms splash 淡出中 + #app 过渡中 → 2s splash 已移除、Vue 接管、样式清理
- [x] typecheck 通过；1376 测试全过