### PR TITLE
fix(download): SSG 模板改写兼容 CRLF

### DIFF
--- a/src/pages/download/ssgTemplate.test.ts
+++ b/src/pages/download/ssgTemplate.test.ts
@@ -47,4 +47,12 @@ describe("renderDownloadTemplate", () => {
       /download-ssg/,
     );
   });
+
+  it("tolerates CRLF line endings (Windows CI checkout with autocrlf)", () => {
+    const crlfHtml = indexHtml.replace(/\r?\n/g, "\r\n");
+    const crlfOut = renderDownloadTemplate(crlfHtml);
+    expect(crlfOut).toContain(`<title>${DOWNLOAD_PAGE.title}</title>`);
+    expect(crlfOut).not.toContain("app-splash");
+    expect(crlfOut).toContain('"SoftwareApplication"');
+  });
 });

--- a/src/pages/download/ssgTemplate.ts
+++ b/src/pages/download/ssgTemplate.ts
@@ -42,7 +42,8 @@ function replaceMetaContent(html: string, selector: string, content: string, lab
 }
 
 export function renderDownloadTemplate(indexHTML: string): string {
-  let html = indexHTML;
+  // Windows CI 检出默认 autocrlf=true，模板会是 CRLF——统一成 LF 再匹配
+  let html = indexHTML.replace(/\r\n/g, "\n");
 
   // ── title / 基础 meta ──
   html = replaceOnce(html, /<title>[\s\S]*?<\/title>/, `<title>${DOWNLOAD_PAGE.title}</title>`, "title");


### PR DESCRIPTION
桌面端 CI build-only 验证暴露：Windows runner 默认 autocrlf=true，index.html 检出为 CRLF，splash 剔除正则失配导致 vite-ssg 构建失败（fail-loud 按设计触发）。入口归一为 LF + CRLF 回归测试。