### PR TITLE
fix(download): splash 剔除模式兼容 Windows 构建产物

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# 统一 LF 检出：Windows CI（autocrlf）与本地跨平台协作下避免 CRLF 导致的
+# 构建差异（曾导致 /download SSG 模板改写在 Windows 构建时失配）。
+* text=auto eol=lf
+
+# vendored 第三方产物不做行尾转换，避免无谓 diff
+examples/qiankun-host/vendor/** -text

--- a/src/pages/download/ssgTemplate.test.ts
+++ b/src/pages/download/ssgTemplate.test.ts
@@ -55,4 +55,17 @@ describe("renderDownloadTemplate", () => {
     expect(crlfOut).not.toContain("app-splash");
     expect(crlfOut).toContain('"SoftwareApplication"');
   });
+
+  // Windows 构建产物里 splash </div> 与 </body> 之间可能没有换行（CI 实测），
+  // 源模板里入口 <script> 也可能被 Vite 提升到 <head>——结构变体都要能剔除干净。
+  it("strips splash across structural variants of the built template", () => {
+    const scriptTag = '    <script type="module" src="/src/main.ts"></script>';
+    expect(indexHtml).toContain(scriptTag);
+
+    const hoistedScript = indexHtml.replace(`${scriptTag}\n`, ""); // 脚本提升到 head，body 尾部只剩 </div>\n</body>
+    expect(renderDownloadTemplate(hoistedScript)).not.toContain("app-splash");
+
+    const glued = indexHtml.replace(`</div>\n${scriptTag}`, "</div></body>"); // </div> 后直接 </body>
+    expect(renderDownloadTemplate(glued)).not.toContain("app-splash");
+  });
 });

--- a/src/pages/download/ssgTemplate.ts
+++ b/src/pages/download/ssgTemplate.ts
@@ -87,9 +87,18 @@ export function renderDownloadTemplate(indexHTML: string): string {
 
   // ── 剔除 splash（样式块 + 标记块），锚点是 index.html 里两处独有注释 ──
   // splash 标记块的后随元素在源模板里是入口 <script>，但 Vite 构建会把入口脚本
-  // 提升到 <head>，届时后随元素是 </body>——两种结构都兼容。
-  html = replaceOnce(html, /[ \t]*<!-- 启动画面关键样式[\s\S]*?<\/style>\n/, "", "splash style");
-  html = replaceOnce(html, /[ \t]*<!-- 启动画面：[\s\S]*?<\/div>\n(?=[ \t]*(?:<script|<\/body>))/, "", "splash markup");
+  // 提升到 <head>，届时后随元素是 </body>——两种结构都兼容；尾部空白用 \s*
+  // 兜底（Windows 构建产物里 </div> 与 </body> 之间可能没有换行）。
+  html = replaceOnce(html, /[ \t]*<!-- 启动画面关键样式[\s\S]*?<\/style>\s*/, "", "splash style");
+  // 失配时带上 </body> 前的原文样本——各平台构建产物结构有差异，日志里直接可见
+  const splashMarkup = /[ \t]*<!-- 启动画面：[\s\S]*?<\/div>\s*(?=<script|<\/body>)/;
+  if (!splashMarkup.test(html)) {
+    const bodyEnd = html.lastIndexOf("</body>");
+    const sample = (bodyEnd === -1 ? html.slice(-500) : html.slice(Math.max(0, bodyEnd - 500), bodyEnd + 20))
+      .replace(/\n/g, "\\n");
+    throw new Error(`[download-ssg] 模板改写失败：未命中「splash markup」。body 尾部样本：${sample}`);
+  }
+  html = html.replace(splashMarkup, "");
   if (html.includes("app-splash")) {
     throw new Error("[download-ssg] 模板改写失败：splash 标记未剔除干净");
   }


### PR DESCRIPTION
第二轮 build-only 验证：CRLF 修复生效（splash style 通过），splash markup 仍失配——构建产物结构差异。模式放宽 + 失配诊断样本 + .gitattributes 统一 LF。