### PR TITLE
fix(ci): Windows 上传步骤显式使用 bash

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -173,8 +173,11 @@ jobs:
           esac
           ls -la "$OUT"
 
+      # 必须显式 bash：Windows 默认 shell 是 pwsh，`$VAR` 取不到环境变量
+      # （曾导致 gh release upload "" → "release not found"）
       - name: Upload to release (tag push)
         if: github.event_name == 'push'
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "$GITHUB_REF_NAME" release-assets/* --clobber


### PR DESCRIPTION
desktop-v0.2.0 首发时 Windows 的 gh release upload 在默认 pwsh 下展开 $GITHUB_REF_NAME 为空 → release not found。显式 shell: bash；随后用 gh run rerun 补传 exe 资产。