### PR TITLE
feat(download): 兜底版本 desktop-v0.2.0 + canonical 尾斜杠

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,7 +81,7 @@ jobs:
               "host": "image.honlnk.com",
               "key": "gpt-image-studio-indexnow-b15468a5",
               "keyLocation": "https://image.honlnk.com/gpt-image-studio-indexnow-b15468a5.txt",
-              "urlList": ["https://image.honlnk.com/", "https://image.honlnk.com/download"]
+              "urlList": ["https://image.honlnk.com/", "https://image.honlnk.com/download/"]
             }' || true
 
   pr-preview:

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -7,7 +7,7 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://image.honlnk.com/download</loc>
+    <loc>https://image.honlnk.com/download/</loc>
     <lastmod>2026-09-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>

--- a/src/pages/download/content.ts
+++ b/src/pages/download/content.ts
@@ -10,7 +10,8 @@
 
 export const DOWNLOAD_PAGE = {
   path: "/download",
-  url: "https://image.honlnk.com/download",
+  // canonical/OG 用带尾斜杠的最终 URL（GH Pages 对无斜杠目录 URL 返回 301）
+  url: "https://image.honlnk.com/download/",
   title: "下载 GPT Image Studio 桌面版 - macOS / Windows / Linux",
   description:
     "免费开源的本地优先 AI 图片创作工作台桌面版：内嵌 Companion 服务开箱即连，无需安装 Node。提供 macOS（Apple Silicon）/ Windows / Linux 安装包，附 macOS 未签名放行教程。",

--- a/src/shared/downloads.ts
+++ b/src/shared/downloads.ts
@@ -43,19 +43,34 @@ export type DesktopReleaseInfo = {
 };
 
 /**
- * 兜底 release（当前线上唯一版本，2026-06 手动发布，早于内嵌 sidecar）。
- * 资产名是 GitHub 网页上传时点号化后的历史命名，属正常情况——
- * releaseClient 的模式匹配对点/空格/连字符三种命名风格都兼容。
+ * 兜底 release（desktop-v0.2.0，CI 首发：首个内嵌 Companion sidecar 的版本）。
+ * 资产命名遵循 desktop-release.yml 头部契约；releaseClient 的模式匹配对
+ * 点/空格/连字符三种历史命名风格都兼容。
  */
 export const FALLBACK_RELEASE: DesktopReleaseInfo = {
-  version: "0.1.0",
-  tag: "desktop-v0.1.0",
-  publishedAt: "2026-06-19T16:06:29Z",
+  version: "0.2.0",
+  tag: "desktop-v0.2.0",
+  publishedAt: "2026-09-11T17:24:23Z",
   assets: {
     macArm64: {
-      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.1.0/GPT.Image.Studio_0.1.0_aarch64.dmg",
-      name: "GPT.Image.Studio_0.1.0_aarch64.dmg",
-      sizeBytes: 1972875,
+      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.0/GPT-Image-Studio_0.2.0_aarch64.dmg",
+      name: "GPT-Image-Studio_0.2.0_aarch64.dmg",
+      sizeBytes: 29279556,
+    },
+    windowsX64: {
+      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.0/GPT-Image-Studio_0.2.0_x64-setup.exe",
+      name: "GPT-Image-Studio_0.2.0_x64-setup.exe",
+      sizeBytes: 32994423,
+    },
+    linuxAppImage: {
+      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.0/GPT-Image-Studio_0.2.0_amd64.AppImage",
+      name: "GPT-Image-Studio_0.2.0_amd64.AppImage",
+      sizeBytes: 112888312,
+    },
+    linuxDeb: {
+      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.0/GPT-Image-Studio_0.2.0_amd64.deb",
+      name: "GPT-Image-Studio_0.2.0_amd64.deb",
+      sizeBytes: 40977026,
     },
   },
 };


### PR DESCRIPTION
桌面端 v0.2.0 四平台资产已发布。FALLBACK_RELEASE 同步为实际资产；canonical/OG/sitemap/IndexNow 统一尾斜杠。