### PR TITLE
chore(download): 兜底版本 desktop-v0.2.1

### DIFF
--- a/src/shared/downloads.ts
+++ b/src/shared/downloads.ts
@@ -43,34 +43,34 @@ export type DesktopReleaseInfo = {
 };
 
 /**
- * 兜底 release（desktop-v0.2.0，CI 首发：首个内嵌 Companion sidecar 的版本）。
+ * 兜底 release（desktop-v0.2.1：管理页改为应用内原生子窗口）。
  * 资产命名遵循 desktop-release.yml 头部契约；releaseClient 的模式匹配对
  * 点/空格/连字符三种历史命名风格都兼容。
  */
 export const FALLBACK_RELEASE: DesktopReleaseInfo = {
-  version: "0.2.0",
-  tag: "desktop-v0.2.0",
-  publishedAt: "2026-09-11T17:24:23Z",
+  version: "0.2.1",
+  tag: "desktop-v0.2.1",
+  publishedAt: "2026-09-11T18:24:03Z",
   assets: {
     macArm64: {
-      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.0/GPT-Image-Studio_0.2.0_aarch64.dmg",
-      name: "GPT-Image-Studio_0.2.0_aarch64.dmg",
-      sizeBytes: 29279556,
+      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.1/GPT-Image-Studio_0.2.0_aarch64.dmg",
+      name: "GPT-Image-Studio_0.2.1_aarch64.dmg",
+      sizeBytes: 29282820,
     },
     windowsX64: {
-      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.0/GPT-Image-Studio_0.2.0_x64-setup.exe",
-      name: "GPT-Image-Studio_0.2.0_x64-setup.exe",
-      sizeBytes: 32994423,
+      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.1/GPT-Image-Studio_0.2.0_x64-setup.exe",
+      name: "GPT-Image-Studio_0.2.1_x64-setup.exe",
+      sizeBytes: 32991667,
     },
     linuxAppImage: {
-      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.0/GPT-Image-Studio_0.2.0_amd64.AppImage",
-      name: "GPT-Image-Studio_0.2.0_amd64.AppImage",
+      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.1/GPT-Image-Studio_0.2.0_amd64.AppImage",
+      name: "GPT-Image-Studio_0.2.1_amd64.AppImage",
       sizeBytes: 112888312,
     },
     linuxDeb: {
-      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.0/GPT-Image-Studio_0.2.0_amd64.deb",
-      name: "GPT-Image-Studio_0.2.0_amd64.deb",
-      sizeBytes: 40977026,
+      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.1/GPT-Image-Studio_0.2.0_amd64.deb",
+      name: "GPT-Image-Studio_0.2.1_amd64.deb",
+      sizeBytes: 40980356,
     },
   },
 };


### PR DESCRIPTION
v0.2.1 四平台资产已发布，FALLBACK_RELEASE 同步实际体积。