### PR TITLE
fix(download): 兜底资产 URL 文件名版本修正

### DIFF
--- a/src/pages/download/releaseClient.test.ts
+++ b/src/pages/download/releaseClient.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { FALLBACK_RELEASE } from "../../shared/downloads";
 import {
   classifyAssets,
   detectPlatform,
@@ -128,5 +129,19 @@ describe("formatAssetSize", () => {
   it("returns empty string for zero/invalid sizes", () => {
     expect(formatAssetSize(0)).toBe("");
     expect(formatAssetSize(Number.NaN)).toBe("");
+  });
+});
+
+describe("FALLBACK_RELEASE 自洽性", () => {
+  // 手动更新兜底版本时 URL/tag/name/version 容易改漏（曾出现 tag 已升 0.2.1
+  // 而 URL 文件名还是 0.2.0 的 404 状态），这里把一致性钉死。
+  it("asset URLs match tag, name and version", () => {
+    for (const asset of Object.values(FALLBACK_RELEASE.assets)) {
+      expect(asset).toBeDefined();
+      expect(asset!.url).toContain(`/download/${FALLBACK_RELEASE.tag}/`);
+      expect(asset!.url.endsWith(`/${asset!.name}`)).toBe(true);
+      expect(asset!.name).toContain(`_${FALLBACK_RELEASE.version}_`);
+      expect(asset!.sizeBytes).toBeGreaterThan(0);
+    }
   });
 });

--- a/src/shared/downloads.ts
+++ b/src/shared/downloads.ts
@@ -53,22 +53,22 @@ export const FALLBACK_RELEASE: DesktopReleaseInfo = {
   publishedAt: "2026-09-11T18:24:03Z",
   assets: {
     macArm64: {
-      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.1/GPT-Image-Studio_0.2.0_aarch64.dmg",
+      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.1/GPT-Image-Studio_0.2.1_aarch64.dmg",
       name: "GPT-Image-Studio_0.2.1_aarch64.dmg",
       sizeBytes: 29282820,
     },
     windowsX64: {
-      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.1/GPT-Image-Studio_0.2.0_x64-setup.exe",
+      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.1/GPT-Image-Studio_0.2.1_x64-setup.exe",
       name: "GPT-Image-Studio_0.2.1_x64-setup.exe",
       sizeBytes: 32991667,
     },
     linuxAppImage: {
-      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.1/GPT-Image-Studio_0.2.0_amd64.AppImage",
+      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.1/GPT-Image-Studio_0.2.1_amd64.AppImage",
       name: "GPT-Image-Studio_0.2.1_amd64.AppImage",
       sizeBytes: 112888312,
     },
     linuxDeb: {
-      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.1/GPT-Image-Studio_0.2.0_amd64.deb",
+      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.1/GPT-Image-Studio_0.2.1_amd64.deb",
       name: "GPT-Image-Studio_0.2.1_amd64.deb",
       sizeBytes: 40980356,
     },


### PR DESCRIPTION
修上一提交的部分替换遗漏（URL 文件名仍为 0.2.0 → 404），并加 FALLBACK_RELEASE 自洽性测试防复发。