### PR TITLE
feat(desktop): 分发收尾 + 桌面端 v0.3.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,8 @@ See `docs/plans/roadmap.md` for the full business roadmap. Current status:
 - Done: Tauri v2 desktop packaging first version (`desktop/src-tauri`, `docs/guides/desktop-packaging.md`)
 - Done: Finer image-library filters — `ImageLibrary.vue` adds search, source filter (generated/edited/imported via `classifyImageSource`), format filter, sort (time/name/size + asc/desc); client-side filter with "partial load" hint for paginated "all" scope
 - Done: Error feedback polish — `feedbackStore` adds info/warning variants; `renameImage`/`setImageTagColor`/`deleteImage` rollback on persist failure; `generationStore` separates image-save failure from generation failure; `reportStorageError` adds throttled toast; `settingsModal.images` filters transient masks
-- Upcoming: desktop signing/notarization/cross-platform builds/updater (Companion sidecar embedding is done)
+- Done: Desktop distribution wrap-up — `scripts/install-desktop.sh` (macOS curl|sh zero-warning install), README/Release-notes template (`.github/release-notes-desktop.md`), in-app lightweight 检查更新 (`src/services/desktopUpdate.ts`, settings → About panel, desktop-only)
+- Upcoming: desktop signing/notarization, real Tauri updater (needs signing), companion keychain
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -66,11 +66,25 @@ JWT_SECRET=xxx ADMIN_API_KEY=xxx docker compose --profile companion-server up -d
 
 ### 方式四：桌面端
 
-下载安装包（含 macOS 安装指引）：**[image.honlnk.com/download](https://image.honlnk.com/download)**
+下载安装包（含各平台图文安装指引）：**[image.honlnk.com/download](https://image.honlnk.com/download)**
+
+**macOS（Apple Silicon）推荐一行命令安装**——终端下载不触发 Gatekeeper，全程零警告：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/honlnk/gpt-image-studio/main/scripts/install-desktop.sh | sh
+```
+
+浏览器直接下载的用户，首次打开需放行一次（安装包未做平台签名/公证，属开源免签名软件的正常提示，详见下载页说明）：
+
+- **macOS**：系统设置 → 隐私与安全性 → 下拉点「仍要打开」；或终端执行 `xattr -cr /Applications/GPT\ Image\ Studio.app`
+- **Windows**：SmartScreen 蓝色提示点「更多信息 → 仍要运行」
+- **Linux**：AppImage 加执行权限即可运行，无安全拦截
+
+开发构建（需 [Rust](docs/guides/desktop-packaging.md#前置依赖)）：
 
 ```bash
 pnpm dev:desktop      # 开发模式
-pnpm build:desktop    # 构建 .app / .dmg（macOS，需 Rust）
+pnpm build:desktop    # 构建 .app / .dmg（macOS）
 ```
 
 详见 [桌面端打包方案](docs/guides/desktop-packaging.md)。

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpt-image-studio"
-version = "0.2.1"
+version = "0.3.0"
 description = "Local-first AI image creation workbench"
 authors = ["honlnk"]
 edition = "2021"

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -1,9 +1,12 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Default capability for the GPT Image Studio desktop shell. Only grants the core window permissions needed to display the web app. No shell, filesystem, http, or process access is exposed — the companion (if used) is reached via the webview's native fetch to 127.0.0.1, not through Tauri plugins.",
-  "windows": ["main"],
+  "description": "Default capability for the GPT Image Studio desktop shell. Grants the core window permissions needed to display the web app, plus read-only app version access (core:app:allow-version) for the lightweight check-for-updates feature. No shell, filesystem, http, or process access is exposed — the companion (if used) is reached via the webview's native fetch to 127.0.0.1, not through Tauri plugins.",
+  "windows": [
+    "main"
+  ],
   "permissions": [
-    "core:default"
+    "core:default",
+    "core:app:allow-version"
   ]
 }

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "GPT Image Studio",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "identifier": "com.honlnk.gpt-image-studio",
   "build": {
     "frontendDist": "../../dist",

--- a/docs/TODO-PENDING.md
+++ b/docs/TODO-PENDING.md
@@ -20,9 +20,12 @@ macOS arm64（未签名）+ **内置 Companion sidecar（2026-08 完成，见下
 
 - ✅ 内嵌 Companion 为 sidecar —— 已完成（阶段四 · 方案 B 首期）。Bun `build --compile` 单文件二进制 + `sqliteDriver.ts` 运行时适配（Node=better-sqlite3 / Bun=bun:sqlite，绕过 V8 addon 在 JSC 无法加载的限制）；Tauri 壳管理生命周期（复用 19750 已有实例 / spawn + COMPANION_READY 握手 / 临时端口重试 / 退出清理）；webview 自动连接、模式锁定、回落 standalone。原两个阻塞项的实际情况：Node 二进制化由 Bun 解决；macOS notarization 对 sidecar 的已知问题（tauri#11992）在未签名期不构成阻塞，做签名时再处理。
 - 🔲 macOS 代码签名 + notarization（需 Apple Developer 账号；当前走免签名路线，见 `docs/plans/desktop-distribution-plan.md`；签名时需处理 sidecar 二进制的 notarization）
-- 🔲 Windows / Linux 跨平台构建（CI 矩阵已就绪：`.github/workflows/desktop-release.yml`，待首次发布实际验证；build-sidecar.mjs 的 Windows `.exe` 后缀已处理）
-- 🔲 Tauri updater 自动更新（未签名 macOS 不可用 updater；轻量替代「检查更新」见分发方案 §4.5）
+- 🔲 Windows / Linux 跨平台构建（CI 矩阵已就绪：`.github/workflows/desktop-release.yml`，desktop-v0.2.x 已实际验证；build-sidecar.mjs 的 Windows `.exe` 后缀已处理）
+- 🔲 Tauri updater 自动更新（未签名 macOS 不可用 updater；轻量替代「检查更新」已落地——见下）
 - ✅ CI 自动构建 + 发布 —— 已完成（免签名路线，无需签名凭据）：tag `desktop-v*` 触发三平台构建 + prerelease 发布，细化设计见 `docs/plans/desktop-ci-cd-plan.md`（2026-09-11）
+- ✅ macOS 安装脚本 —— 已完成（分发方案 §4.2）：`scripts/install-desktop.sh`，curl 下载不写隔离标记实现零警告安装；架构检测（仅 arm64）、Releases 列表 API 解析最新版本（prerelease 兼容）、DMG 挂载复制、已有旧版先删再装、防御性 `xattr -cr`
+- ✅ README + Release 说明模板 —— 已完成（分发方案 §4.3）：`.github/release-notes-desktop.md`（CI `sed` 替换版本号）；README「方式四：桌面端」补一行命令安装入口与各平台放行说明
+- ✅ 应用内「检查更新」—— 已完成（分发方案 §4.5 轻量替代）：`src/services/desktopUpdate.ts`（对比 Releases 列表 API 与当前版本，失败明确报错不回落兜底常量）+ 设置 → 关于面板的桌面端专属卡片（有新版时 `openExternalUrl` 打开 Release 页）；capability 增加 `core:app:allow-version`
 
 ---
 

--- a/docs/guides/desktop-packaging.md
+++ b/docs/guides/desktop-packaging.md
@@ -181,7 +181,7 @@ pnpm tauri icon desktop/src-tauri/app-icon.png -o desktop/src-tauri/icons
 
 - **macOS 代码签名 / notarization**：需要 Apple Developer 账号。当前决策走**免签名路线**（`docs/plans/desktop-distribution-plan.md`）：`pnpm build:desktop` 产出未签名 app，首次打开需在「系统设置 → 隐私与安全性」里手动允许。若将来做签名，需注意 sidecar 二进制的 notarization 已知问题（[tauri#11992](https://github.com/tauri-apps/tauri/issues/11992)）。
 - **Windows / Linux 跨平台构建**：CI 矩阵已就绪（`.github/workflows/desktop-release.yml`，含 Linux webkit2gtk 依赖与 Windows `.exe` 后缀处理），待首次发布实际验证。
-- **自动更新（Tauri updater）**：未签名的 macOS 不可用 updater；轻量替代方案「检查更新」见分发方案 §4.5。
+- **自动更新（Tauri updater）**：未签名的 macOS 不可用 updater；轻量替代「检查更新」已落地（设置 → 关于，`src/services/desktopUpdate.ts`，分发方案 §4.5）。
 - **多 provider 前端管理 UI**：凭据管理仍走 admin 页（阶段四后续项）。
 - **NativeStorage（APP 本地文件存储替代 IndexedDB）**：阶段四后续项，接口骨架已预留。
 
@@ -190,9 +190,9 @@ pnpm tauri icon desktop/src-tauri/app-icon.png -o desktop/src-tauri/icons
 按免签名分发方案（`docs/plans/desktop-distribution-plan.md` §四）的依赖顺序：
 
 1. ~~CI 自动构建~~ —— 已完成（`desktop-release.yml`，tag `desktop-v*` 触发；细化设计见 `docs/plans/desktop-ci-cd-plan.md`）。
-2. 安装脚本 `scripts/install-desktop.sh`（macOS 主力分发方式；下载页已预留位置）。
-3. 下载页 `image.honlnk.com/download`（计划见 `docs/plans/download-page-plan.md`）。
+2. ~~安装脚本 `scripts/install-desktop.sh`~~ —— 已完成（2026-09-12，macOS 主力分发方式；下载页已预留位置）。
+3. ~~下载页 `image.honlnk.com/download`~~ —— 已完成（计划见 `docs/plans/download-page-plan.md`）。
 4. SignPath Foundation 免费签名（触发式：Windows 用户对 SmartScreen 投诉时申请）。
-5. 应用内「检查更新」（对比 GitHub releases 与当前版本，`openExternalUrl` 引导）。
+5. ~~应用内「检查更新」~~ —— 已完成（2026-09-12，`src/services/desktopUpdate.ts` + 设置 → 关于面板，对比 GitHub Releases 与当前版本，`openExternalUrl` 引导）。真·Tauri updater 仍需签名后评估。
 6. 评估是否需要把 IndexedDB 迁移到 Tauri 的文件系统存储（目前 IndexedDB 在 WKWebView 下持久化正常，暂无必要）。
 7. 多 provider 前端管理 UI / keychain 凭据加密（阶段四启动时再决策）。

--- a/docs/plans/desktop-distribution-plan.md
+++ b/docs/plans/desktop-distribution-plan.md
@@ -100,9 +100,13 @@ README「桌面端」小节 + 每个 Release 的发布说明里，写清两步�
 
 ### 4.2 安装脚本 `scripts/install-desktop.sh`（依赖 4.1）
 
+> ✅ **已落地（2026-09-12）**：按 3.1 职责清单实现。两处与早期设想的偏差：① 版本解析走 Releases **列表** API 而非 `/releases/latest`（桌面版是 prerelease，后者取不到，与下载页 releaseClient 同理）；② 旧版替换前先 `osascript` 尝试退出运行中的 app。已通过真实 Release 资产验证版本解析与下载链接有效性；发布前仍建议在新机器/已有旧版两种场景各跑一遍。
+
 按 3.1 的职责清单实现。发布前用真实 Release 资产完整跑一遍（新机器、已有旧版两种情况）。
 
 ### 4.3 README + Release 说明模板（不依赖 CI，可立即做）
+
+> ✅ **已落地（2026-09-12）**：`.github/release-notes-desktop.md`（CI `sed` 替换 `{{VERSION}}`，随 desktop-release.yml 注入）；README「方式四：桌面端」补了一行命令安装入口（curl\|sh）与 macOS / Windows / Linux 三平台放行说明。
 
 按 3.2 写好两平台文案；Release notes 做成可复用模板（放 `.github/` 或文档里）。
 
@@ -111,6 +115,8 @@ README「桌面端」小节 + 每个 Release 的发布说明里，写清两步�
 触发条件：Windows 用户对 SmartScreen 提示反馈较多。通过后把签名步骤接进 4.1 的 Windows job。
 
 ### 4.5 （后置）应用内「检查更新」
+
+> ✅ **已落地（2026-09-12）**：`src/services/desktopUpdate.ts` + 设置 → 关于面板的桌面端专属卡片（仅 Tauri 运行时渲染）。版本号经 `getVersion()`（`@tauri-apps/api/app`）读取，capability 增加 `core:app:allow-version`；有新版时 `openExternalUrl` 打开对应 Release 页。与下载页的差异：API 失败**不**回落 FALLBACK_RELEASE（对硬编码旧版本比较会误报「已是最新」），明确报错让用户重试。
 
 macOS 未签名**做不了 Tauri updater 静默自动更新**（updater 要求已签名 app）。替代轻方案：设置里加「检查更新」，对比 GitHub `releases/latest` 与当前版本，有新版则提示并打开 Release 页（复用已有的 `openExternalUrl`）。Windows/Linux 将来如果做了签名可再评估真 updater。
 

--- a/scripts/bump-desktop-version.sh
+++ b/scripts/bump-desktop-version.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# 一键同步桌面端版本号（desktop-ci-cd-plan §七.3 / §八.1）。
+#
+# 用法：scripts/bump-desktop-version.sh 0.3.0
+#
+# 同步两处（tag 校验时比较的正是这两处，见 desktop-release.yml）：
+#   1. desktop/src-tauri/tauri.conf.json  —— 顶层 "version"
+#   2. desktop/src-tauri/Cargo.toml       —— [package] version
+#
+# 不做的事（保持手动，见 §八）：
+#   - companion/package.json（仅 companion 有改动时才需同步并发 companion-v*）
+#   - src/shared/downloads.ts 的 FALLBACK_RELEASE（资产体积要等 CI 构建完才知道）
+
+set -eu
+
+cd "$(dirname "$0")/.."
+
+fail() { printf '✖ %s\n' "$1" >&2; exit 1; }
+
+VERSION="${1:-}"
+[ -n "$VERSION" ] || fail "用法：scripts/bump-desktop-version.sh <x.y.z>（例如 0.3.0）"
+printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' \
+  || fail "版本号必须是三段 semver（x.y.z），收到：${VERSION}"
+
+TAG="desktop-v${VERSION}"
+if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
+  fail "本地已存在 tag ${TAG}，请换一个版本号。"
+fi
+
+TAURI_CONF="desktop/src-tauri/tauri.conf.json"
+CARGO_TOML="desktop/src-tauri/Cargo.toml"
+
+OLD_CONF="$(sed -n 's/^  "version": "\([^"]*\)",/\1/p' "$TAURI_CONF")"
+OLD_CARGO="$(awk -F'"' '/^\[package\]/{p=1} /^\[/&&!/^\[package\]/{p=0} p&&/^version = /{print $2; exit}' "$CARGO_TOML")"
+[ -n "$OLD_CONF" ] || fail "未能在 ${TAURI_CONF} 找到顶层 version 字段。"
+[ -n "$OLD_CARGO" ] || fail "未能在 ${CARGO_TOML} 找到 [package] version 字段。"
+[ "$OLD_CONF" = "$OLD_CARGO" ] \
+  || fail "两处当前版本不一致（tauri.conf.json=${OLD_CONF}，Cargo.toml=${OLD_CARGO}），请先手动对齐。"
+[ "$OLD_CONF" != "$VERSION" ] || fail "版本号未变化（当前已是 ${VERSION}）。"
+
+# tauri.conf.json：顶层 version 是唯一两空格缩进的 "version" 键
+sed -i '' "s/^  \"version\": \"${OLD_CONF}\"/  \"version\": \"${VERSION}\"/" "$TAURI_CONF"
+
+# Cargo.toml：只改 [package] 段内的 version（[dependencies] 里还有别的 version）
+awk -v ver="$VERSION" '
+  /^\[package\]/ { in_pkg=1 }
+  /^\[/ && !/^\[package\]/ { in_pkg=0 }
+  in_pkg && /^version = "/ { sub(/"[^"]*"/, "\"" ver "\"") }
+  { print }
+' "$CARGO_TOML" > "${CARGO_TOML}.tmp" && mv "${CARGO_TOML}.tmp" "$CARGO_TOML"
+
+# 回读校验
+NEW_CONF="$(sed -n 's/^  "version": "\([^"]*\)",/\1/p' "$TAURI_CONF")"
+NEW_CARGO="$(awk -F'"' '/^\[package\]/{p=1} /^\[/&&!/^\[package\]/{p=0} p&&/^version = /{print $2; exit}' "$CARGO_TOML")"
+[ "$NEW_CONF" = "$VERSION" ] && [ "$NEW_CARGO" = "$VERSION" ] \
+  || fail "写入校验失败（tauri.conf.json=${NEW_CONF}，Cargo.toml=${NEW_CARGO}）。"
+
+printf '✔ 版本号已同步：%s → %s\n' "$OLD_CONF" "$VERSION"
+printf '\n后续步骤：\n'
+printf '  1. 提交合并进 main\n'
+printf '  2. git tag %s && git push origin %s\n' "$TAG" "$TAG"
+printf '  3. CI 构建完成后手动更新 src/shared/downloads.ts 的 FALLBACK_RELEASE\n'
+printf '  4. 检查 https://image.honlnk.com/download 已解析到新版本\n'

--- a/scripts/install-desktop.sh
+++ b/scripts/install-desktop.sh
@@ -1,0 +1,136 @@
+#!/bin/sh
+# GPT Image Studio 桌面端安装脚本（macOS）
+#
+# 用法：
+#   curl -fsSL https://raw.githubusercontent.com/honlnk/gpt-image-studio/main/scripts/install-desktop.sh | sh
+#   curl -fsSL ... | sh -s 0.2.1        # 安装指定版本（默认最新）
+#
+# 原理：命令行 curl 下载的文件不带 com.apple.quarantine 隔离属性，
+# Gatekeeper 不检查 → 未签名 app 全程零警告安装（免签名分发方案 §3.1）。
+#
+# 资产命名契约（desktop-release.yml / desktop-ci-cd-plan §六）：
+#   GPT-Image-Studio_<version>_aarch64.dmg
+
+set -eu
+
+REPO="honlnk/gpt-image-studio"
+APP_NAME="GPT Image Studio"
+APP_DIR="/Applications"
+API_URL="https://api.github.com/repos/${REPO}/releases?per_page=20"
+TAG_PREFIX="desktop-v"
+
+# --- 输出辅助（管道到 sh 时也可能没有 tty，颜色用前先判断） ---
+if [ -t 1 ]; then
+  BOLD="$(printf '\033[1m')"
+  RED="$(printf '\033[31m')"
+  GREEN="$(printf '\033[32m')"
+  DIM="$(printf '\033[2m')"
+  RESET="$(printf '\033[0m')"
+else
+  BOLD="" RED="" GREEN="" DIM="" RESET=""
+fi
+
+info() { printf '%s==>%s %s\n' "$BOLD" "$RESET" "$1"; }
+ok() { printf '%s✔%s %s\n' "$GREEN" "$RESET" "$1"; }
+fail() { printf '%s✖ 安装失败：%s%s\n' "$RED" "$1" "$RESET" >&2; exit 1; }
+
+# --- 临时目录与清理 ---
+TMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t gpt-image-studio)"
+MOUNT_DIR="${TMP_DIR}/dmg-mount"
+DMG_PATH=""
+MOUNTED=0
+
+cleanup() {
+  if [ "$MOUNTED" -eq 1 ]; then
+    hdiutil detach "$MOUNT_DIR" -quiet >/dev/null 2>&1 || true
+  fi
+  rm -rf "$TMP_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# --- 0. 平台检查 ---
+[ "$(uname -s)" = "Darwin" ] || fail "本脚本仅支持 macOS；Windows / Linux 请从 https://image.honlnk.com/download 下载安装包。"
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  arm64) ASSET_SUFFIX="aarch64.dmg" ;;
+  x86_64) fail "暂只提供 Apple Silicon（arm64）安装包，Intel Mac 版本尚未发布。可关注 https://github.com/${REPO}/releases" ;;
+  *) fail "无法识别的 CPU 架构：${ARCH}" ;;
+esac
+
+# --- 1. 解析版本（默认最新 desktop-v* release） ---
+# 注意：桌面版以 prerelease 发布，/releases/latest 端点取不到，必须用列表 API
+# （匿名访问本就看不到 draft，无需额外过滤）。
+REQUESTED_VERSION="${1:-}"
+if [ -n "$REQUESTED_VERSION" ]; then
+  TAG="${REQUESTED_VERSION#${TAG_PREFIX}}"
+  TAG="${TAG_PREFIX}${TAG}"
+else
+  info "查询最新版本…"
+  RELEASES_JSON="$(curl -fsSL "$API_URL")" || fail "无法访问 GitHub Releases API（网络问题或触发限流），可稍后重试或手动下载：https://github.com/${REPO}/releases"
+  TAG="$(printf '%s' "$RELEASES_JSON" \
+    | grep -o "\"tag_name\":[[:space:]]*\"${TAG_PREFIX}[^\"]*\"" \
+    | head -n 1 \
+    | sed "s/.*\"\(${TAG_PREFIX}[^\"]*\)\"/\1/")"
+  [ -n "$TAG" ] || fail "未找到任何桌面版 release（${TAG_PREFIX}*）。"
+fi
+VERSION="${TAG#${TAG_PREFIX}}"
+info "目标版本：${BOLD}${VERSION}${RESET}（${TAG}）"
+
+# --- 2. 下载 DMG ---
+ASSET_NAME="GPT-Image-Studio_${VERSION}_${ASSET_SUFFIX}"
+DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${TAG}/${ASSET_NAME}"
+DMG_PATH="${TMP_DIR}/${ASSET_NAME}"
+
+info "下载 ${ASSET_NAME}…"
+printf '%s     %s%s\n' "$DIM" "$DOWNLOAD_URL" "$RESET"
+curl -fSL --retry 2 -o "$DMG_PATH" "$DOWNLOAD_URL" \
+  || fail "下载失败（版本号可能不存在或网络中断）：${DOWNLOAD_URL}"
+[ -s "$DMG_PATH" ] || fail "下载产物为空文件。"
+
+# --- 3. 挂载 DMG 并复制 .app ---
+mkdir -p "$MOUNT_DIR"
+info "挂载 DMG…"
+hdiutil attach -nobrowse -readonly -mountpoint "$MOUNT_DIR" "$DMG_PATH" >/dev/null \
+  || fail "hdiutil 挂载失败（DMG 可能损坏，请重试）。"
+MOUNTED=1
+
+SOURCE_APP="${MOUNT_DIR}/${APP_NAME}.app"
+[ -d "$SOURCE_APP" ] || fail "DMG 内未找到 ${APP_NAME}.app（包结构异常）。"
+
+TARGET_APP="${APP_DIR}/${APP_NAME}.app"
+
+# /Applications 不可写时（非管理员账户）用 sudo 完成替换
+SUDO=""
+if [ ! -w "$APP_DIR" ]; then
+  command -v sudo >/dev/null 2>&1 || fail "${APP_DIR} 不可写且 sudo 不可用，请手动安装。"
+  SUDO="sudo"
+  info "${APP_DIR} 需要管理员权限，可能提示输入密码。"
+fi
+
+# 已在运行则先退出（忽略失败——没运行时 pkill 返回 1）。
+# 用 pkill 而非 osascript：后者会把没在运行的 app 拉起来再退，且需自动化权限。
+pkill -f "${APP_DIR}/${APP_NAME}.app/Contents/MacOS" 2>/dev/null || true
+
+if [ -d "$TARGET_APP" ]; then
+  info "移除旧版本…"
+  $SUDO rm -rf "$TARGET_APP" || fail "无法删除旧版本 ${TARGET_APP}（可手动删除后重试）。"
+fi
+
+info "安装到 ${APP_DIR}…"
+$SUDO cp -R "$SOURCE_APP" "$TARGET_APP" || fail "复制 ${APP_NAME}.app 到 ${APP_DIR} 失败。"
+
+hdiutil detach "$MOUNT_DIR" -quiet >/dev/null 2>&1 || true
+MOUNTED=0
+
+# --- 4. 防御性清除隔离属性（curl 下载本不带标记，防用户环境链路写入） ---
+$SUDO xattr -cr "$TARGET_APP" 2>/dev/null || true
+
+# --- 5. 完成 ---
+[ -d "$TARGET_APP" ] || fail "安装后未找到 ${TARGET_APP}。"
+printf '\n'
+ok "${BOLD}${APP_NAME} ${VERSION}${RESET}${GREEN} 安装完成${RESET}"
+printf '    启动方式：启动台搜索「%s」，或终端执行：\n' "$APP_NAME"
+printf '    %sopen -a "%s"%s\n' "$BOLD" "$APP_NAME" "$RESET"
+printf '\n'
+printf '%s提示：应用内嵌 Companion 服务，首次启动稍慢属正常现象。%s\n' "$DIM" "$RESET"

--- a/src/components/settings/AboutPanel.vue
+++ b/src/components/settings/AboutPanel.vue
@@ -7,8 +7,33 @@ import {
   QQ_GROUP_NUMBER,
   QQ_GROUP_QR_URL,
 } from "../../shared/community";
+import { openExternalUrl } from "../../services/desktopCompanion";
+import {
+  checkDesktopUpdate,
+  getDesktopAppVersion,
+  type DesktopUpdateStatus,
+} from "../../services/desktopUpdate";
+import { isTauriRuntime } from "../../services/storage/resolveStorage";
 
 const { stars: starCount, failed: starFailed } = useRepoStars();
+
+/** 检查更新仅桌面端可用（Web 版随部署持续更新，无此诉求）。 */
+const isDesktop = isTauriRuntime();
+const currentVersion = ref<string | null>(null);
+const updateChecking = ref(false);
+const updateStatus = ref<DesktopUpdateStatus | null>(null);
+
+async function runUpdateCheck() {
+  if (updateChecking.value) return;
+  updateChecking.value = true;
+  try {
+    const result = await checkDesktopUpdate();
+    updateStatus.value = result;
+    if (result.kind !== "error") currentVersion.value = result.currentVersion;
+  } finally {
+    updateChecking.value = false;
+  }
+}
 
 /** 前端实时生成的高分辨率二维码，比原图缩略图更易扫描。 */
 const qrDataUrl = ref<string>(QQ_GROUP_QR_URL);
@@ -23,6 +48,9 @@ onMounted(async () => {
   } catch {
     // 生成失败时回退到原图
     qrDataUrl.value = QQ_GROUP_QR_URL;
+  }
+  if (isDesktop) {
+    currentVersion.value = await getDesktopAppVersion();
   }
 });
 
@@ -120,6 +148,53 @@ const techStack = ["Vue 3", "TypeScript", "Tailwind CSS v4", "Tauri"];
             />
           </svg>
         </a>
+      </div>
+
+      <div
+        v-if="isDesktop"
+        class="mt-4 rounded-lg border border-gray-200 px-3 py-2.5"
+      >
+        <div class="flex items-center gap-2">
+          <span class="text-sm text-gray-600">桌面版</span>
+          <span class="text-sm font-semibold text-gray-900">
+            {{ currentVersion ? `v${currentVersion}` : "…" }}
+          </span>
+          <button
+            type="button"
+            class="ml-auto cursor-pointer rounded-md bg-gray-900 px-3 py-1.5 text-sm text-white hover:bg-gray-700 disabled:opacity-50"
+            :disabled="updateChecking"
+            @click="runUpdateCheck"
+          >
+            {{ updateChecking ? "检查中…" : "检查更新" }}
+          </button>
+        </div>
+        <p
+          v-if="updateStatus?.kind === 'up-to-date'"
+          class="mt-1.5 text-xs text-green-600"
+        >
+          已是最新版本
+        </p>
+        <div
+          v-else-if="updateStatus?.kind === 'update-available'"
+          class="mt-1.5 flex items-center gap-2 text-xs"
+        >
+          <span class="text-amber-600">
+            发现新版本 v{{ updateStatus.latestVersion }}
+          </span>
+          <button
+            type="button"
+            class="cursor-pointer font-medium text-blue-600 hover:text-blue-800"
+            @click="openExternalUrl(updateStatus.releaseUrl)"
+          >
+            前往下载 →
+          </button>
+        </div>
+        <p
+          v-else-if="updateStatus?.kind === 'error'"
+          class="mt-1.5 text-xs text-gray-400"
+        >
+          检查失败，请检查网络后重试
+        </p>
       </div>
 
       <div class="mt-4 flex flex-wrap gap-1.5">

--- a/src/pages/download/MacInstallGuide.vue
+++ b/src/pages/download/MacInstallGuide.vue
@@ -1,26 +1,30 @@
 <script setup lang="ts">
 /**
- * macOS 安装教学区：未签名应用的 Gatekeeper 放行指引。
- * 文案与分发方案 §3.2 一致（docs/plans/desktop-distribution-plan.md）；
- * 安装脚本（curl|sh）区块在 §4.2 完成后补充到本区顶部作为「推荐方式」。
+ * macOS 安装教学区。
+ * 顶部是推荐方式：curl|sh 一行命令安装（命令行下载不写隔离标记，
+ * Gatekeeper 零警告，见分发方案 §3.1）；下方为浏览器手动下载的
+ * Gatekeeper 放行指引（文案与分发方案 §3.2 一致）。
  */
 import { ref } from "vue";
 
+const INSTALL_COMMAND =
+  "curl -fsSL https://raw.githubusercontent.com/honlnk/gpt-image-studio/main/scripts/install-desktop.sh | sh";
 const XATTR_COMMAND = "xattr -cr /Applications/GPT\\ Image\\ Studio.app";
 
-const copied = ref(false);
+/** 当前显示「已复制」反馈的命令 key；空串表示无。 */
+const copiedKey = ref("");
 let copiedTimer: ReturnType<typeof setTimeout> | undefined;
 
-async function copyCommand() {
+async function copyCommand(key: string, text: string) {
   let ok = false;
   try {
-    await navigator.clipboard.writeText(XATTR_COMMAND);
+    await navigator.clipboard.writeText(text);
     ok = true;
   } catch {
     // clipboard API 不可用/被拒（部分 webview、权限策略）时退化到
     // 隐藏 textarea + execCommand 的老路径
     const textarea = document.createElement("textarea");
-    textarea.value = XATTR_COMMAND;
+    textarea.value = text;
     textarea.style.position = "fixed";
     textarea.style.opacity = "0";
     document.body.appendChild(textarea);
@@ -34,14 +38,42 @@ async function copyCommand() {
   }
   // 两条通道都失败才静默——命令文本就在页面上，用户可手选复制
   if (!ok) return;
-  copied.value = true;
+  copiedKey.value = key;
   clearTimeout(copiedTimer);
-  copiedTimer = setTimeout(() => (copied.value = false), 2000);
+  copiedTimer = setTimeout(() => (copiedKey.value = ""), 2000);
 }
 </script>
 
 <template>
   <h2 class="text-2xl font-bold tracking-tight">macOS 安装指引</h2>
+
+  <!-- 推荐方式：一行命令安装（curl 下载不带隔离属性，全程不触发 Gatekeeper） -->
+  <div class="mt-6 rounded-2xl border border-emerald-200 bg-emerald-50/70 p-5">
+    <div class="flex items-center gap-2">
+      <span class="rounded-md bg-emerald-600 px-2 py-0.5 text-xs font-semibold text-white">推荐方式</span>
+      <div class="font-medium">终端一行命令安装，全程零警告</div>
+    </div>
+    <p class="mt-2 text-sm leading-relaxed text-gray-600">
+      命令行下载的文件不会被 macOS 标记隔离，Gatekeeper 不会拦截——复制下面这行到「终端」执行，
+      自动完成下载、安装到「应用程序」，装完直接打开，无需下面的手动放行步骤：
+    </p>
+    <div class="mt-3 flex items-center gap-2 rounded-xl border border-gray-200 bg-gray-950 px-4 py-3">
+      <code class="min-w-0 flex-1 overflow-x-auto font-mono text-[13px] whitespace-nowrap text-emerald-300">{{ INSTALL_COMMAND }}</code>
+      <button
+        type="button"
+        class="shrink-0 cursor-pointer rounded-lg bg-gray-800 px-3 py-1.5 text-xs font-medium text-gray-200 transition-colors hover:bg-gray-700"
+        @click="copyCommand('install', INSTALL_COMMAND)"
+      >
+        {{ copiedKey === "install" ? "已复制 ✓" : "复制" }}
+      </button>
+    </div>
+    <p class="mt-2 text-xs text-gray-400">
+      脚本内容公开可审计：<a href="https://github.com/honlnk/gpt-image-studio/blob/main/scripts/install-desktop.sh" target="_blank" rel="noopener" class="underline underline-offset-2 hover:text-gray-600">scripts/install-desktop.sh</a>
+    </p>
+  </div>
+
+  <!-- 手动方式：浏览器下载 dmg 后的 Gatekeeper 放行指引 -->
+  <p class="mt-10 text-sm font-semibold text-gray-900">手动安装（浏览器下载）</p>
   <p class="mt-2 text-sm leading-relaxed text-gray-500">
     安装包没有购买 Apple 开发者签名（$99/年，对本项目没有性价比），首次打开会被
     Gatekeeper 拦一次。这是<strong class="font-medium text-gray-700">开源未签名软件的正常提示，不是病毒</strong>——
@@ -83,9 +115,9 @@ async function copyCommand() {
           <button
             type="button"
             class="shrink-0 cursor-pointer rounded-lg bg-gray-800 px-3 py-1.5 text-xs font-medium text-gray-200 transition-colors hover:bg-gray-700"
-            @click="copyCommand"
+            @click="copyCommand('xattr', XATTR_COMMAND)"
           >
-            {{ copied ? "已复制 ✓" : "复制" }}
+            {{ copiedKey === "xattr" ? "已复制 ✓" : "复制" }}
           </button>
         </div>
       </div>

--- a/src/services/desktopUpdate.test.ts
+++ b/src/services/desktopUpdate.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { checkDesktopUpdate, compareVersions } from "./desktopUpdate";
+
+const RELEASES_WITH_DESKTOP_021 = [
+  {
+    tag_name: "desktop-v0.2.1",
+    published_at: "2026-09-12T00:00:00Z",
+    draft: false,
+    assets: [
+      {
+        name: "GPT-Image-Studio_0.2.1_aarch64.dmg",
+        browser_download_url: "https://example.com/dmg",
+        size: 1,
+      },
+    ],
+  },
+  {
+    tag_name: "desktop-v0.2.0",
+    published_at: "2026-09-11T00:00:00Z",
+    draft: false,
+    assets: [],
+  },
+  { tag_name: "companion-v9.9.9", published_at: "2026-09-13T00:00:00Z", draft: false, assets: [] },
+];
+
+function okFetch(body: unknown): typeof fetch {
+  return (() =>
+    Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    )) as typeof fetch;
+}
+
+function failingFetch(): typeof fetch {
+  return (() => Promise.reject(new Error("network down"))) as typeof fetch;
+}
+
+describe("compareVersions", () => {
+  it("compares numeric segments, not strings", () => {
+    expect(compareVersions("0.2.10", "0.2.9")).toBe(1);
+    expect(compareVersions("0.2.9", "0.2.10")).toBe(-1);
+  });
+
+  it("treats missing segments as 0 and ignores v prefix", () => {
+    expect(compareVersions("0.2", "0.2.0")).toBe(0);
+    expect(compareVersions("v1.0.0", "1.0.0")).toBe(0);
+  });
+
+  it("orders major/minor/patch", () => {
+    expect(compareVersions("1.0.0", "0.9.9")).toBe(1);
+    expect(compareVersions("0.3.0", "0.2.99")).toBe(1);
+    expect(compareVersions("0.2.1", "0.2.1")).toBe(0);
+  });
+});
+
+describe("checkDesktopUpdate", () => {
+  it("reports update-available when the latest desktop release is newer", async () => {
+    const result = await checkDesktopUpdate({
+      currentVersion: "0.2.0",
+      fetchImpl: okFetch(RELEASES_WITH_DESKTOP_021),
+    });
+    expect(result).toEqual({
+      kind: "update-available",
+      currentVersion: "0.2.0",
+      latestVersion: "0.2.1",
+      releaseUrl:
+        "https://github.com/honlnk/gpt-image-studio/releases/tag/desktop-v0.2.1",
+    });
+  });
+
+  it("reports up-to-date when current matches or exceeds the latest release", async () => {
+    expect(
+      await checkDesktopUpdate({
+        currentVersion: "0.2.1",
+        fetchImpl: okFetch(RELEASES_WITH_DESKTOP_021),
+      }),
+    ).toEqual({ kind: "up-to-date", currentVersion: "0.2.1", latestVersion: "0.2.1" });
+    // 本地版本比线上新（开发中）也算 up-to-date，不提示「更新」
+    expect(
+      await checkDesktopUpdate({
+        currentVersion: "0.3.0",
+        fetchImpl: okFetch(RELEASES_WITH_DESKTOP_021),
+      }),
+    ).toEqual({ kind: "up-to-date", currentVersion: "0.3.0", latestVersion: "0.2.1" });
+  });
+
+  it("ignores non-desktop tags (companion-v*)", async () => {
+    const result = await checkDesktopUpdate({
+      currentVersion: "0.2.1",
+      fetchImpl: okFetch([
+        { tag_name: "companion-v9.9.9", published_at: "", draft: false, assets: [] },
+      ]),
+    });
+    expect(result.kind).toBe("error");
+  });
+
+  it("returns error on network failure / non-200 / malformed payloads", async () => {
+    expect(
+      (await checkDesktopUpdate({ currentVersion: "0.2.0", fetchImpl: failingFetch() })).kind,
+    ).toBe("error");
+    const notOk = (() =>
+      Promise.resolve(new Response("nope", { status: 403 }))) as typeof fetch;
+    expect(
+      (await checkDesktopUpdate({ currentVersion: "0.2.0", fetchImpl: notOk })).kind,
+    ).toBe("error");
+    expect(
+      (
+        await checkDesktopUpdate({
+          currentVersion: "0.2.0",
+          fetchImpl: okFetch({ not: "an array" }),
+        })
+      ).kind,
+    ).toBe("error");
+  });
+
+  it("returns error when current version is unavailable", async () => {
+    const result = await checkDesktopUpdate({
+      currentVersion: null,
+      fetchImpl: okFetch(RELEASES_WITH_DESKTOP_021),
+    });
+    expect(result.kind).toBe("error");
+  });
+});

--- a/src/services/desktopUpdate.ts
+++ b/src/services/desktopUpdate.ts
@@ -1,0 +1,106 @@
+/**
+ * 桌面端「检查更新」轻量方案（免签名分发 §4.5）。
+ *
+ * 背景：未签名的 macOS app 无法使用 Tauri updater 静默更新（updater 要求已签名
+ * 包），因此采用「手动检查 + 跳转 Release 页」的替代方案：
+ * 对比 GitHub Releases 列表 API 与当前 app 版本，有新版则提示并外开 Release 页。
+ *
+ * 注意：桌面版以 prerelease 发布，/releases/latest 端点取不到，必须用列表 API
+ * （与下载页 releaseClient 相同的数据源；解析逻辑直接复用其纯函数）。
+ * 与下载页不同：检查更新在 API 失败时不回落 FALLBACK_RELEASE——对一个硬编码的
+ * 旧版本号做比较会得出误导性的「已是最新」，明确报错更符合预期。
+ */
+import { GITHUB_RELEASES_URL, type DesktopReleaseInfo } from "../shared/downloads";
+import { pickLatestDesktopRelease } from "../pages/download/releaseClient";
+import { isTauriRuntime } from "./storage/resolveStorage";
+
+const RELEASES_API =
+  "https://api.github.com/repos/honlnk/gpt-image-studio/releases?per_page=20";
+
+export type DesktopUpdateStatus =
+  | {
+      kind: "update-available";
+      currentVersion: string;
+      latestVersion: string;
+      /** 对应 Release 页 URL（…/releases/tag/desktop-vX.Y.Z）。 */
+      releaseUrl: string;
+    }
+  | { kind: "up-to-date"; currentVersion: string; latestVersion: string }
+  | { kind: "error" };
+
+/**
+ * 语义化版本比较：a < b 返回 -1，相等返回 0，a > b 返回 1。
+ * 容忍 v 前缀、缺失段按 0 计（"0.2" == "0.2.0"），非数字段按 0 处理——
+ * 桌面版 tag 是干净的三段 semver，这里只需避免 "0.2.10" < "0.2.9" 的字符串比较陷阱。
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.replace(/^v/i, "").split(/[.-]/);
+  const pb = b.replace(/^v/i, "").split(/[.-]/);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const na = Number.parseInt(pa[i] ?? "0", 10);
+    const nb = Number.parseInt(pb[i] ?? "0", 10);
+    const va = Number.isNaN(na) ? 0 : na;
+    const vb = Number.isNaN(nb) ? 0 : nb;
+    if (va !== vb) return va < vb ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * 取当前桌面 app 版本（tauri.conf.json 的 version，经 @tauri-apps/api）。
+ * 非 Tauri 运行时或读取失败返回 null。`@tauri-apps/api` 动态 import：
+ * Web 构建（GitHub Pages）不打包该依赖。
+ */
+export async function getDesktopAppVersion(): Promise<string | null> {
+  if (!isTauriRuntime()) return null;
+  try {
+    const { getVersion } = await import("@tauri-apps/api/app");
+    return await getVersion();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 检查桌面端是否有新版本。任何失败（网络、限流、超时、无 desktop tag、
+ * 版本号读不到）都收敛为 { kind: "error" }，由 UI 提示稍后重试。
+ */
+export async function checkDesktopUpdate(options?: {
+  /** 缺省时经 Tauri API 读取；测试/桌面外调用可显式传入。 */
+  currentVersion?: string | null;
+  /** 缺省用全局 fetch；测试注入。 */
+  fetchImpl?: typeof fetch;
+}): Promise<DesktopUpdateStatus> {
+  const fetchImpl = options?.fetchImpl ?? fetch;
+  const currentVersion =
+    options?.currentVersion !== undefined
+      ? options.currentVersion
+      : await getDesktopAppVersion();
+  if (!currentVersion) return { kind: "error" };
+
+  let latest: DesktopReleaseInfo | null = null;
+  try {
+    const response = await fetchImpl(RELEASES_API, {
+      headers: { Accept: "application/vnd.github+json" },
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!response.ok) return { kind: "error" };
+    const releases: unknown = await response.json();
+    if (!Array.isArray(releases)) return { kind: "error" };
+    latest = pickLatestDesktopRelease(releases);
+  } catch {
+    return { kind: "error" };
+  }
+  if (!latest) return { kind: "error" };
+
+  if (compareVersions(latest.version, currentVersion) > 0) {
+    return {
+      kind: "update-available",
+      currentVersion,
+      latestVersion: latest.version,
+      releaseUrl: `${GITHUB_RELEASES_URL}/tag/${latest.tag}`,
+    };
+  }
+  return { kind: "up-to-date", currentVersion, latestVersion: latest.version };
+}


### PR DESCRIPTION
## 内容

- **应用内检查更新**（设置 → 关于，仅桌面端）：对比 GitHub Releases 与当前版本，有新版一键直达 Release 页；capability 增加 `core:app:allow-version`
- **macOS 安装脚本** `scripts/install-desktop.sh`：curl|sh 零警告安装，本机实测新装/覆盖两场景
- **下载页** macOS 指引区新增「推荐方式」一行命令安装卡片
- **README** 桌面端安装说明重写（三平台放行指引）
- **`scripts/bump-desktop-version.sh`** 一键版本同步脚本
- 文档状态同步（TODO-PENDING / 分发方案 / 打包指南）

发版：合并后打 `desktop-v0.3.0` tag 触发三平台 CI 构建。

## 验证

- 1429 测试全过、vue-tsc 干净
- 检查更新两条路径（已是最新/发现新版本+跳转）已在 dev:desktop 实测
- 安装脚本端到端实测（含 Gatekeeper 零警告启动验证）