### PR TITLE
chore(download): 兜底版本更新至 desktop-v0.3.0

### DIFF
--- a/src/shared/downloads.ts
+++ b/src/shared/downloads.ts
@@ -43,34 +43,34 @@ export type DesktopReleaseInfo = {
 };
 
 /**
- * 兜底 release（desktop-v0.2.1：管理页改为应用内原生子窗口）。
+ * 兜底 release（desktop-v0.3.0：应用内检查更新 + macOS 安装脚本发布）。
  * 资产命名遵循 desktop-release.yml 头部契约；releaseClient 的模式匹配对
  * 点/空格/连字符三种历史命名风格都兼容。
  */
 export const FALLBACK_RELEASE: DesktopReleaseInfo = {
-  version: "0.2.1",
-  tag: "desktop-v0.2.1",
-  publishedAt: "2026-09-11T18:24:03Z",
+  version: "0.3.0",
+  tag: "desktop-v0.3.0",
+  publishedAt: "2026-09-12T17:27:53Z",
   assets: {
     macArm64: {
-      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.1/GPT-Image-Studio_0.2.1_aarch64.dmg",
-      name: "GPT-Image-Studio_0.2.1_aarch64.dmg",
-      sizeBytes: 29282820,
+      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.3.0/GPT-Image-Studio_0.3.0_aarch64.dmg",
+      name: "GPT-Image-Studio_0.3.0_aarch64.dmg",
+      sizeBytes: 29284227,
     },
     windowsX64: {
-      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.1/GPT-Image-Studio_0.2.1_x64-setup.exe",
-      name: "GPT-Image-Studio_0.2.1_x64-setup.exe",
-      sizeBytes: 32991667,
+      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.3.0/GPT-Image-Studio_0.3.0_x64-setup.exe",
+      name: "GPT-Image-Studio_0.3.0_x64-setup.exe",
+      sizeBytes: 32995498,
     },
     linuxAppImage: {
-      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.1/GPT-Image-Studio_0.2.1_amd64.AppImage",
-      name: "GPT-Image-Studio_0.2.1_amd64.AppImage",
-      sizeBytes: 112888312,
+      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.3.0/GPT-Image-Studio_0.3.0_amd64.AppImage",
+      name: "GPT-Image-Studio_0.3.0_amd64.AppImage",
+      sizeBytes: 112892408,
     },
     linuxDeb: {
-      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.2.1/GPT-Image-Studio_0.2.1_amd64.deb",
-      name: "GPT-Image-Studio_0.2.1_amd64.deb",
-      sizeBytes: 40980356,
+      url: "https://github.com/honlnk/gpt-image-studio/releases/download/desktop-v0.3.0/GPT-Image-Studio_0.3.0_amd64.deb",
+      name: "GPT-Image-Studio_0.3.0_amd64.deb",
+      sizeBytes: 40981970,
     },
   },
 };


### PR DESCRIPTION
发版流程 §八.4：desktop-v0.3.0 CI 构建完成，用真实资产体积更新 FALLBACK_RELEASE 兜底常量。主链路（API 解析）不受影响，仅提升 API 失败时的兜底新鲜度。