### PR TITLE
feat(ui): 自绘下拉全量替换 + 桌面端 v0.3.1

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpt-image-studio"
-version = "0.3.0"
+version = "0.3.1"
 description = "Local-first AI image creation workbench"
 authors = ["honlnk"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "GPT Image Studio",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.honlnk.gpt-image-studio",
   "build": {
     "frontendDist": "../../dist",

--- a/src/components/settings/ApiSettingsPanel.vue
+++ b/src/components/settings/ApiSettingsPanel.vue
@@ -48,6 +48,11 @@ const apiModeOptions: Array<{ value: ApiMode; label: string; description: string
   { value: "responses", label: "Responses API", description: "通过 /v1/responses 调用 image_generation 工具。" },
 ];
 const partialImageOptions = [0, 1, 2, 3] as const;
+// DropdownSelect 以字符串值工作，这里把数值选项拍平成 {value,label}。
+const partialImageSelectOptions = partialImageOptions.map((count) => ({
+  value: String(count),
+  label: String(count),
+}));
 const apiBaseUrlHint = computed(() =>
   props.apiBaseUrlMode === "full"
     ? props.apiMode === "responses"
@@ -378,22 +383,15 @@ onUnmounted(() => {
           >
             中间图数量
           </label>
-          <select
+          <DropdownSelect
             id="streamPartialImages"
-            :value="streamPartialImages"
-            class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 outline-none focus:border-gray-500 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400"
             :disabled="!streamImages"
-            @change="
-              emit(
-                'update:streamPartialImages',
-                Number(($event.target as HTMLSelectElement).value) as 0 | 1 | 2 | 3,
-              )
+            :model-value="String(streamPartialImages)"
+            :options="partialImageSelectOptions"
+            @update:model-value="
+              emit('update:streamPartialImages', Number($event) as 0 | 1 | 2 | 3)
             "
-          >
-            <option v-for="count in partialImageOptions" :key="count" :value="count">
-              {{ count }}
-            </option>
-          </select>
+          />
           <p class="mt-1.5 text-xs text-gray-500">
             建议保留默认值 1。设置为 0 时仍可开启流式，但不会请求中间图。
           </p>

--- a/src/components/studio/ImageLibrary.vue
+++ b/src/components/studio/ImageLibrary.vue
@@ -18,6 +18,7 @@ import {
   imageTagDotColor,
 } from "../image-library/imageTagColors";
 import StorageUsagePanel from "../image-library/StorageUsagePanel.vue";
+import DropdownSelect from "../ui/DropdownSelect.vue";
 
 type SortKey = "time" | "name" | "size";
 type SortDirection = "asc" | "desc";
@@ -66,6 +67,24 @@ const availableFormats = computed(() => {
   }
   return Array.from(seen, ([value, label]) => ({ value, label }));
 });
+
+// 三个筛选下拉的选项（自绘 DropdownSelect 需要 {value,label} 数组）。
+const sourceOptions = [
+  { value: "all", label: "全部来源" },
+  ...Object.entries(SOURCE_CLASS_LABELS).map(([value, label]) => ({
+    value,
+    label,
+  })),
+];
+const formatOptions = computed(() => [
+  { value: "all", label: "全部格式" },
+  ...availableFormats.value,
+]);
+const SORT_OPTIONS: ReadonlyArray<{ value: SortKey; label: string }> = [
+  { value: "time", label: "时间" },
+  { value: "name", label: "名称" },
+  { value: "size", label: "大小" },
+];
 
 const trimmedSearch = computed(() => searchText.value.trim().toLowerCase());
 
@@ -233,10 +252,9 @@ function toggleSortDirection() {
   sortDirection.value = sortDirection.value === "asc" ? "desc" : "asc";
 }
 
-function onSortKeyChange(event: Event) {
-  const value = (event.target as HTMLSelectElement).value as SortKey;
+function onSortKeyChange(value: string) {
   if (value !== sortKey.value) {
-    sortKey.value = value;
+    sortKey.value = value as SortKey;
     track("library.sort_changed", {
       target: "images",
       key: value,
@@ -245,16 +263,12 @@ function onSortKeyChange(event: Event) {
   }
 }
 
-function onSourceFilterChange(event: Event) {
-  const value = (event.target as HTMLSelectElement).value as
-    | "all"
-    | ImageSourceClass;
-  sourceFilter.value = value;
+function onSourceFilterChange(value: string) {
+  sourceFilter.value = value as "all" | ImageSourceClass;
   track("library.filter_by_source", { source: value });
 }
 
-function onFormatFilterChange(event: Event) {
-  const value = (event.target as HTMLSelectElement).value;
+function onFormatFilterChange(value: string) {
   formatFilter.value = value;
   track("library.filter_by_format", { format: value });
 }
@@ -455,40 +469,30 @@ function setImageTagColor(
       </div>
 
       <div class="mt-2 grid grid-cols-3 gap-1.5">
-        <select
-          :value="sourceFilter"
+        <DropdownSelect
           aria-label="按来源筛选"
-          class="min-w-0 cursor-pointer rounded-md border border-gray-200 bg-white px-1.5 py-1 text-xs text-gray-700 focus:outline-none focus:ring-1 focus:ring-gray-400"
-          @change="onSourceFilterChange"
-        >
-          <option value="all">全部来源</option>
-          <option v-for="(label, key) in SOURCE_CLASS_LABELS" :key="key" :value="key">
-            {{ label }}
-          </option>
-        </select>
-        <select
-          :value="formatFilter"
+          :model-value="sourceFilter"
+          :options="sourceOptions"
+          size="sm"
+          @update:model-value="onSourceFilterChange"
+        />
+        <DropdownSelect
           aria-label="按格式筛选"
-          class="min-w-0 cursor-pointer rounded-md border border-gray-200 bg-white px-1.5 py-1 text-xs text-gray-700 focus:outline-none focus:ring-1 focus:ring-gray-400"
           :disabled="availableFormats.length === 0"
-          @change="onFormatFilterChange"
-        >
-          <option value="all">全部格式</option>
-          <option v-for="fmt in availableFormats" :key="fmt.value" :value="fmt.value">
-            {{ fmt.label }}
-          </option>
-        </select>
+          :model-value="formatFilter"
+          :options="formatOptions"
+          size="sm"
+          @update:model-value="onFormatFilterChange"
+        />
         <div class="flex min-w-0 items-center gap-0.5">
-          <select
-            :value="sortKey"
+          <DropdownSelect
             aria-label="排序方式"
-            class="min-w-0 flex-1 cursor-pointer rounded-md border border-gray-200 bg-white px-1.5 py-1 text-xs text-gray-700 focus:outline-none focus:ring-1 focus:ring-gray-400"
-            @change="onSortKeyChange"
-          >
-            <option value="time">时间</option>
-            <option value="name">名称</option>
-            <option value="size">大小</option>
-          </select>
+            class="min-w-0 flex-1"
+            :model-value="sortKey"
+            :options="SORT_OPTIONS"
+            size="sm"
+            @update:model-value="onSortKeyChange"
+          />
           <button
             :aria-label="sortDirection === 'asc' ? '升序' : '降序'"
             class="shrink-0 cursor-pointer rounded-md border border-gray-200 bg-white px-1.5 py-1 text-gray-600 hover:bg-gray-50"

--- a/src/components/ui/DropdownSelect.vue
+++ b/src/components/ui/DropdownSelect.vue
@@ -9,12 +9,18 @@ import { computed, onBeforeUnmount, ref, watch } from "vue";
  * 方向键移动高亮、Enter 选中。浮层挂在 .relative 容器内，供普通表单
  * （非固定定位的弹窗内容）复用。
  */
-const props = defineProps<{
-  options: ReadonlyArray<{ value: string; label: string }>;
-  modelValue: string;
-  id?: string;
-  disabled?: boolean;
-}>();
+const props = withDefaults(
+  defineProps<{
+    options: ReadonlyArray<{ value: string; label: string }>;
+    modelValue: string;
+    id?: string;
+    ariaLabel?: string;
+    disabled?: boolean;
+    /** md：表单场景（设置页）；sm：工具条紧凑场景（图片库筛选）。 */
+    size?: "md" | "sm";
+  }>(),
+  { size: "md" },
+);
 
 const emit = defineEmits<{
   "update:modelValue": [value: string];
@@ -96,8 +102,14 @@ onBeforeUnmount(() => {
     <button
       :id="id"
       :aria-expanded="open"
+      :aria-label="ariaLabel"
       aria-haspopup="listbox"
-      class="flex w-full cursor-pointer items-center justify-between gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-left text-sm text-gray-900 outline-none focus:border-gray-500 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400"
+      class="flex w-full min-w-0 cursor-pointer items-center justify-between gap-2 border bg-white text-left outline-none disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400"
+      :class="
+        size === 'sm'
+          ? 'rounded-md border-gray-200 px-1.5 py-1 text-xs text-gray-700 focus:border-gray-400'
+          : 'rounded-lg border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-gray-500'
+      "
       :disabled="disabled"
       type="button"
       @click="toggle"
@@ -105,8 +117,8 @@ onBeforeUnmount(() => {
       <span class="truncate">{{ selectedLabel }}</span>
       <svg
         aria-hidden="true"
-        class="h-4 w-4 shrink-0 text-gray-400 transition-transform"
-        :class="open ? 'rotate-180' : ''"
+        class="shrink-0 text-gray-400 transition-transform"
+        :class="[size === 'sm' ? 'h-3 w-3' : 'h-4 w-4', open ? 'rotate-180' : '']"
         fill="none"
         stroke="currentColor"
         stroke-linecap="round"
@@ -121,7 +133,8 @@ onBeforeUnmount(() => {
     <ul
       v-if="open"
       :aria-labelledby="id"
-      class="absolute left-0 right-0 top-full z-30 mt-1 max-h-60 overflow-y-auto rounded-lg border border-gray-200 bg-white py-1 shadow-lg"
+      class="absolute left-0 top-full z-30 mt-1 max-h-60 overflow-y-auto rounded-lg border border-gray-200 bg-white py-1 shadow-lg"
+      :class="size === 'sm' ? 'w-max min-w-full' : 'right-0'"
       role="listbox"
     >
       <li
@@ -131,8 +144,9 @@ onBeforeUnmount(() => {
         role="option"
       >
         <button
-          class="flex w-full cursor-pointer items-center justify-between gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-gray-50"
+          class="flex w-full cursor-pointer items-center justify-between gap-2 text-left transition-colors hover:bg-gray-50"
           :class="[
+            size === 'sm' ? 'px-2 py-1.5 text-xs' : 'px-3 py-2 text-sm',
             activeIndex === index ? 'bg-gray-50' : '',
             option.value === modelValue
               ? 'font-medium text-gray-900'
@@ -146,7 +160,8 @@ onBeforeUnmount(() => {
           <svg
             v-if="option.value === modelValue"
             aria-hidden="true"
-            class="h-4 w-4 shrink-0 text-gray-900"
+            class="shrink-0 text-gray-900"
+            :class="size === 'sm' ? 'h-3 w-3' : 'h-4 w-4'"
             fill="none"
             stroke="currentColor"
             stroke-linecap="round"


### PR DESCRIPTION
## 内容

- **feat(ui)**: 项目内残余的 4 个原生 `<select>` 全部替换为自绘 DropdownSelect
  - DropdownSelect 新增 `size="sm"` 紧凑变体 + `ariaLabel` 支持
  - 图片库筛选条：来源 / 格式 / 排序三个下拉
  - 设置 → 接口 → 中间图数量
- **chore(release)**: 桌面端版本号 0.3.0 → 0.3.1

## 验证

- typecheck + 1429 测试全过
- dev 环境真实鼠标事件验证：展开 / 选中 / 选后关闭 / 相邻下拉互斥关闭 / disabled 态
- 本次发布**故意不更新 FALLBACK_RELEASE**，验证下载页运行时动态解析最新版本的能力